### PR TITLE
feat(BE): GitHub OAuth 인증 및 JWT 토큰 발급 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -28,11 +28,18 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'com.h2database:h2'
+    testImplementation 'org.wiremock:wiremock-standalone:3.12.1'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/backend/src/main/java/com/edurican/enchelinbe/auth/AuthService.java
+++ b/backend/src/main/java/com/edurican/enchelinbe/auth/AuthService.java
@@ -1,0 +1,39 @@
+package com.edurican.enchelinbe.auth;
+
+import com.edurican.enchelinbe.enums.RoleEnum;
+import com.edurican.enchelinbe.repository.UserRepository;
+import com.edurican.enchelinbe.service.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final GitHubClient gitHubClient;
+    private final UserRepository userRepository;
+    private final JwtProvider jwtProvider;
+
+    @Transactional
+    public String login(String code) {
+        String accessToken = gitHubClient.exchangeCode(code);
+        GitHubUserInfo userInfo = gitHubClient.getUserInfo(accessToken);
+
+        User user = userRepository.findByGithubId(userInfo.id())
+                .map(existing -> {
+                    existing.updateProfile(userInfo.login(), userInfo.avatarUrl());
+                    return existing;
+                })
+                .orElseGet(() -> userRepository.save(User.builder()
+                        .githubId(userInfo.id())
+                        .email(userInfo.email() != null ? userInfo.email() : "")
+                        .nickname(userInfo.login())
+                        .avatarUrl(userInfo.avatarUrl())
+                        .htmlUrl(userInfo.htmlUrl())
+                        .role(RoleEnum.NORMAL)
+                        .build()));
+
+        return jwtProvider.createToken(user.getId());
+    }
+}

--- a/backend/src/main/java/com/edurican/enchelinbe/auth/AuthenticatedUser.java
+++ b/backend/src/main/java/com/edurican/enchelinbe/auth/AuthenticatedUser.java
@@ -1,0 +1,11 @@
+package com.edurican.enchelinbe.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthenticatedUser {
+}

--- a/backend/src/main/java/com/edurican/enchelinbe/auth/AuthenticatedUserArgumentResolver.java
+++ b/backend/src/main/java/com/edurican/enchelinbe/auth/AuthenticatedUserArgumentResolver.java
@@ -1,0 +1,32 @@
+package com.edurican.enchelinbe.auth;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+@Component
+public class AuthenticatedUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    public static final String USER_ID_ATTRIBUTE = "authenticatedUserId";
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthenticatedUser.class)
+                && parameter.getParameterType().equals(Long.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory) {
+        HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+        return request.getAttribute(USER_ID_ATTRIBUTE);
+    }
+}

--- a/backend/src/main/java/com/edurican/enchelinbe/auth/GitHubClient.java
+++ b/backend/src/main/java/com/edurican/enchelinbe/auth/GitHubClient.java
@@ -1,0 +1,80 @@
+package com.edurican.enchelinbe.auth;
+
+import com.edurican.enchelinbe.common.exception.BusinessException;
+import com.edurican.enchelinbe.common.exception.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+@Slf4j
+public class GitHubClient {
+
+    private final String clientId;
+    private final String clientSecret;
+    private final RestClient restClient;
+
+    public GitHubClient(
+            @Value("${github.client-id}") String clientId,
+            @Value("${github.client-secret}") String clientSecret) {
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.restClient = RestClient.create();
+    }
+
+    public String exchangeCode(String code) {
+        try {
+            TokenResponse response = restClient.post()
+                    .uri("https://github.com/login/oauth/access_token")
+                    .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                    .body(new TokenRequest(clientId, clientSecret, code))
+                    .retrieve()
+                    .body(TokenResponse.class);
+
+            if (response == null || response.accessToken() == null) {
+                throw new BusinessException(ErrorCode.GITHUB_AUTH_FAILED);
+            }
+            return response.accessToken();
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("GitHub code exchange 실패", e);
+            throw new BusinessException(ErrorCode.GITHUB_AUTH_FAILED);
+        }
+    }
+
+    public GitHubUserInfo getUserInfo(String accessToken) {
+        try {
+            GitHubUserInfo userInfo = restClient.get()
+                    .uri("https://api.github.com/user")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .retrieve()
+                    .body(GitHubUserInfo.class);
+
+            if (userInfo == null) {
+                throw new BusinessException(ErrorCode.GITHUB_AUTH_FAILED);
+            }
+            return userInfo;
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("GitHub 유저 정보 조회 실패", e);
+            throw new BusinessException(ErrorCode.GITHUB_AUTH_FAILED);
+        }
+    }
+
+    record TokenRequest(
+            @JsonProperty("client_id") String clientId,
+            @JsonProperty("client_secret") String clientSecret,
+            String code) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record TokenResponse(@JsonProperty("access_token") String accessToken) {
+    }
+}

--- a/backend/src/main/java/com/edurican/enchelinbe/auth/GitHubUserInfo.java
+++ b/backend/src/main/java/com/edurican/enchelinbe/auth/GitHubUserInfo.java
@@ -1,0 +1,14 @@
+package com.edurican.enchelinbe.auth;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GitHubUserInfo(
+        @JsonProperty("id") String id,
+        @JsonProperty("login") String login,
+        @JsonProperty("email") String email,
+        @JsonProperty("avatar_url") String avatarUrl,
+        @JsonProperty("html_url") String htmlUrl
+) {
+}

--- a/backend/src/main/java/com/edurican/enchelinbe/auth/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/edurican/enchelinbe/auth/JwtAuthenticationFilter.java
@@ -1,0 +1,82 @@
+package com.edurican.enchelinbe.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        String method = request.getMethod();
+
+        // 인증 경로는 스킵
+        if (path.startsWith("/api/auth/")) {
+            return true;
+        }
+
+        // GET 요청은 공개
+        if (HttpMethod.GET.matches(method)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (header == null || !header.startsWith("Bearer ")) {
+            writeUnauthorized(response);
+            return;
+        }
+
+        String token = header.substring(7);
+
+        if (!jwtProvider.validateToken(token)) {
+            writeUnauthorized(response);
+            return;
+        }
+
+        Long userId = jwtProvider.getUserId(token);
+        request.setAttribute(AuthenticatedUserArgumentResolver.USER_ID_ATTRIBUTE, userId);
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void writeUnauthorized(HttpServletResponse response) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        Map<String, Object> body = Map.of(
+                "success", false,
+                "data", Map.of(),
+                "error", Map.of(
+                        "code", "A001",
+                        "message", "인증이 필요합니다."
+                )
+        );
+        objectMapper.writeValue(response.getOutputStream(), body);
+    }
+}

--- a/backend/src/main/java/com/edurican/enchelinbe/auth/JwtProvider.java
+++ b/backend/src/main/java/com/edurican/enchelinbe/auth/JwtProvider.java
@@ -1,0 +1,56 @@
+package com.edurican.enchelinbe.auth;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JwtProvider {
+
+    private final SecretKey secretKey;
+    private final long expiration;
+
+    public JwtProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.expiration}") long expiration) {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.expiration = expiration;
+    }
+
+    public String createToken(Long userId) {
+        Date now = new Date();
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + expiration))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public Long getUserId(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+        return Long.parseLong(claims.getSubject());
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/backend/src/main/java/com/edurican/enchelinbe/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/edurican/enchelinbe/common/exception/ErrorCode.java
@@ -9,11 +9,14 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "C001", "입력값이 올바르지 않습니다."),
 
-    RESTAURANT_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "레스토랑이 존재하지 않습니다."),
-    
-    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "리뷰가 존재하지 않습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A001", "인증이 필요합니다."),
+    GITHUB_AUTH_FAILED(HttpStatus.BAD_REQUEST, "A002", "GitHub 인증에 실패했습니다."),
 
-    INTERNAL_SERVER_ERROR(HttpStatus.BAD_GATEWAY, "C002", "서버 오류입니다.");
+    RESTAURANT_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "레스토랑이 존재하지 않습니다."),
+
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "RV001", "리뷰가 존재하지 않습니다."),
+
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C002", "서버 오류입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/backend/src/main/java/com/edurican/enchelinbe/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/edurican/enchelinbe/common/exception/GlobalExceptionHandler.java
@@ -3,12 +3,24 @@ package com.edurican.enchelinbe.common.exception;
 import com.edurican.enchelinbe.common.response.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 @Slf4j
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidationException(MethodArgumentNotValidException ex) {
+        log.error("Validation 실패: {}", ex.getMessage());
+
+        ErrorCode errorCode = ErrorCode.INVALID_INPUT;
+
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode));
+    }
 
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException ex) {

--- a/backend/src/main/java/com/edurican/enchelinbe/config/FilterConfig.java
+++ b/backend/src/main/java/com/edurican/enchelinbe/config/FilterConfig.java
@@ -1,0 +1,26 @@
+package com.edurican.enchelinbe.config;
+
+import com.edurican.enchelinbe.auth.JwtAuthenticationFilter;
+import com.edurican.enchelinbe.auth.JwtProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class FilterConfig {
+
+    private final JwtProvider jwtProvider;
+    private final ObjectMapper objectMapper;
+
+    @Bean
+    public FilterRegistrationBean<JwtAuthenticationFilter> jwtFilter() {
+        FilterRegistrationBean<JwtAuthenticationFilter> registration = new FilterRegistrationBean<>();
+        registration.setFilter(new JwtAuthenticationFilter(jwtProvider, objectMapper));
+        registration.addUrlPatterns("/*");
+        registration.setOrder(1);
+        return registration;
+    }
+}

--- a/backend/src/main/java/com/edurican/enchelinbe/config/WebConfig.java
+++ b/backend/src/main/java/com/edurican/enchelinbe/config/WebConfig.java
@@ -1,0 +1,21 @@
+package com.edurican.enchelinbe.config;
+
+import com.edurican.enchelinbe.auth.AuthenticatedUserArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthenticatedUserArgumentResolver authenticatedUserArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authenticatedUserArgumentResolver);
+    }
+}

--- a/backend/src/main/java/com/edurican/enchelinbe/controller/AuthController.java
+++ b/backend/src/main/java/com/edurican/enchelinbe/controller/AuthController.java
@@ -1,0 +1,69 @@
+package com.edurican.enchelinbe.controller;
+
+import com.edurican.enchelinbe.auth.AuthService;
+import com.edurican.enchelinbe.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @Value("${github.client-id}")
+    private String clientId;
+
+    @Value("${github.redirect-uri}")
+    private String redirectUri;
+
+    @Value("${app.frontend-url}")
+    private String frontendUrl;
+
+    @GetMapping("/github")
+    public ResponseEntity<Void> redirectToGitHub() {
+        String githubAuthUrl = UriComponentsBuilder
+                .fromUriString("https://github.com/login/oauth/authorize")
+                .queryParam("client_id", clientId)
+                .queryParam("redirect_uri", redirectUri)
+                .queryParam("scope", "read:user user:email")
+                .build()
+                .toUriString();
+
+        return ResponseEntity.status(HttpStatus.FOUND)
+                .header(HttpHeaders.LOCATION, githubAuthUrl)
+                .build();
+    }
+
+    @GetMapping("/github/callback")
+    public ResponseEntity<Void> githubCallback(@RequestParam String code) {
+        String token = authService.login(code);
+
+        String redirectUrl = UriComponentsBuilder
+                .fromUriString(frontendUrl)
+                .path("/auth/callback")
+                .queryParam("token", token)
+                .build()
+                .toUriString();
+
+        return ResponseEntity.status(HttpStatus.FOUND)
+                .header(HttpHeaders.LOCATION, redirectUrl)
+                .build();
+    }
+
+    @PostMapping("/github/token")
+    public ApiResponse<Map<String, String>> githubToken(@RequestBody Map<String, String> request) {
+        String code = request.get("code");
+        String token = authService.login(code);
+        return ApiResponse.success(Map.of("token", token));
+    }
+}

--- a/backend/src/main/java/com/edurican/enchelinbe/repository/UserRepository.java
+++ b/backend/src/main/java/com/edurican/enchelinbe/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.edurican.enchelinbe.repository;
+
+import com.edurican.enchelinbe.service.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByGithubId(String githubId);
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -3,3 +3,15 @@ spring:
   name: enchelin
  profiles:
    active: local
+
+jwt:
+  secret: ${JWT_SECRET:default-dev-secret-key-that-should-be-changed-in-production-env}
+  expiration: ${JWT_EXPIRATION:3600000}
+
+github:
+  client-id: ${GITHUB_CLIENT_ID:}
+  client-secret: ${GITHUB_CLIENT_SECRET:}
+  redirect-uri: ${GITHUB_REDIRECT_URI:http://localhost:8080/api/auth/github/callback}
+
+app:
+  frontend-url: ${APP_FRONTEND_URL:http://localhost:5173}


### PR DESCRIPTION
## 💡 개요
GitHub OAuth를 통한 사용자 인증 및 JWT 토큰 발급 흐름 구현

## 🔗 관련 이슈
Closes #2

## 📝 작업 상세 내용
- [x] GitHubClient: OAuth code → access token 교환, 유저 정보 조회
- [x] AuthService: 로그인/회원가입 처리 및 JWT 발급
- [x] JwtProvider: 토큰 생성/검증
- [x] JwtAuthenticationFilter: 요청별 토큰 인증 필터
- [x] AuthController: `/api/auth/github/callback` 엔드포인트
- [x] FilterConfig, WebConfig: 필터 및 ArgumentResolver 등록

## 👀 체크리스트
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [ ] 로컬에서 테스트는 모두 통과했나요?
- [x] 불필요한 공백이나 주석은 제거했나요?

## 🙏 리뷰 요청 사항
> JWT 토큰 생성/검증 로직과 GitHub OAuth 흐름 확인 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated GitHub OAuth authentication enabling users to log in via GitHub credentials.
  * Implemented JWT-based token authentication system for endpoint authorization.
  * Added authentication endpoints supporting GitHub OAuth callback flow and token retrieval.
  * Introduced user account creation and profile synchronization with GitHub.

* **Chores**
  * Added JWT library and testing infrastructure dependencies.
  * Updated application configuration for authentication and OAuth settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->