### PR TITLE
fix(FE): 카카오맵 SDK 로딩, 지도 표시, 검색 위치 버그 수정

### DIFF
--- a/frontend/src/components/map/KakaoMap.vue
+++ b/frontend/src/components/map/KakaoMap.vue
@@ -111,5 +111,6 @@ onBeforeUnmount(() => {
 .kakao-map {
   width: 100%;
   height: 100%;
+  flex: 1;
 }
 </style>

--- a/frontend/src/views/MapView.vue
+++ b/frontend/src/views/MapView.vue
@@ -46,6 +46,7 @@ const center = ref({ ...DEFAULT_CENTER })
 const locating = ref(true)
 const movedFromOrigin = ref(false)
 let lastSearchPos = { x: 0, y: 0 }
+let currentMapCenter = { x: 0, y: 0 }
 
 function loadRestaurants(x, y) {
   lastSearchPos = { x, y }
@@ -59,6 +60,7 @@ function onMarkerClick(restaurant) {
 }
 
 function onBoundsChanged({ x, y }) {
+  currentMapCenter = { x, y }
   const dx = Math.abs(x - lastSearchPos.x)
   const dy = Math.abs(y - lastSearchPos.y)
   if (dx > 0.005 || dy > 0.005) {
@@ -67,8 +69,8 @@ function onBoundsChanged({ x, y }) {
 }
 
 function searchHere() {
-  center.value = { lat: center.value.lat, lng: center.value.lng }
-  loadRestaurants(lastSearchPos.x + (center.value.lng - lastSearchPos.x), lastSearchPos.y + (center.value.lat - lastSearchPos.y))
+  center.value = { lat: currentMapCenter.y, lng: currentMapCenter.x }
+  loadRestaurants(currentMapCenter.x, currentMapCenter.y)
 }
 
 onMounted(() => {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,6 +6,7 @@ import vueDevTools from 'vite-plugin-vue-devtools'
 
 // https://vite.dev/config/
 export default defineConfig({
+  envDir: '../',
   plugins: [
     vue(),
     vueDevTools(),


### PR DESCRIPTION
## 개요
> 카카오맵 SDK 로딩 실패, 지도 미표시, 검색 위치 오류 3가지 버그를 수정합니다.

## 관련 이슈
Closes #12

## 작업 상세 내용
- [x] `vite.config.js`에 `envDir: '../'` 추가하여 루트 `.env`에서 `VITE_KAKAO_JS_KEY` 참조
- [x] `KakaoMap.vue`에 `flex: 1` 추가하여 flex 레이아웃에서 지도 높이 확보
- [x] `MapView.vue`에 `currentMapCenter` 변수 추가, `searchHere()` 로직을 실제 지도 중심 좌표 기반으로 수정

## 체크리스트
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 로컬에서 테스트는 모두 통과했나요?
- [x] 불필요한 공백이나 주석은 제거했나요?

## 리뷰 요청 사항
> `searchHere()` 로직이 기존에 `center.value` (초기 위치)를 기준으로 계산하던 것을 `currentMapCenter` (실제 지도 중심)로 변경했습니다. 의도대로 동작하는지 확인 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Map container now properly expands and fills available space when used in flexible layouts.
  * Search functionality updated to reference the current map center location for consistent positioning.

* **Chores**
  * Updated environment variable file resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->