### PR TITLE
feat(FE): 검색 기반 지도 재설계 - bounds + 검색창 + 클러스터링 (#16)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "axios": "^1.14.0",
@@ -16,8 +18,11 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.3",
+    "@vue/test-utils": "^2.4.6",
+    "jsdom": "^26.1.0",
     "vite": "^7.3.1",
-    "vite-plugin-vue-devtools": "^8.0.5"
+    "vite-plugin-vue-devtools": "^8.0.5",
+    "vitest": "^3.2.4"
   },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/frontend/src/api/restaurant.js
+++ b/frontend/src/api/restaurant.js
@@ -1,9 +1,39 @@
 import client from './client'
 
-export function fetchNearbyRestaurants(x, y, radius = 1000) {
-  return client.get('/restaurant/nearby', { params: { x, y, radius } })
+/**
+ * 지도 viewport(bounds) 내 리뷰된 식당 목록 조회
+ * @param {{ lat: number, lng: number }} sw - 남서 좌표
+ * @param {{ lat: number, lng: number }} ne - 북동 좌표
+ */
+export function fetchRestaurantsInBounds(sw, ne) {
+  return client.get('/restaurants', {
+    params: {
+      swLng: sw.lng,
+      swLat: sw.lat,
+      neLng: ne.lng,
+      neLat: ne.lat,
+    },
+  })
 }
 
+/**
+ * 카카오 키워드 검색 프록시 (백엔드 경유)
+ * @param {string} query - 검색어
+ * @param {{ x: number, y: number } | null} center - 지도 중심 좌표 (거리순 정렬용)
+ */
+export function searchRestaurants(query, center = null) {
+  const params = { query }
+  if (center) {
+    params.x = center.x
+    params.y = center.y
+  }
+  return client.get('/restaurants/search', { params })
+}
+
+/**
+ * 식당 단건 조회
+ * @param {number} restaurantId
+ */
 export function fetchRestaurantDetail(restaurantId) {
   return client.get(`/restaurants/${restaurantId}`)
 }

--- a/frontend/src/components/map/KakaoMap.vue
+++ b/frontend/src/components/map/KakaoMap.vue
@@ -15,11 +15,16 @@ const emit = defineEmits(['marker-click', 'bounds-changed'])
 
 const mapContainer = ref(null)
 let map = null
+let clusterer = null
 let kakaoMarkers = []
 let activeInfoWindow = null
 
 function clearMarkers() {
-  kakaoMarkers.forEach((m) => m.setMap(null))
+  if (clusterer) {
+    clusterer.clear()
+  } else {
+    kakaoMarkers.forEach((m) => m.setMap(null))
+  }
   kakaoMarkers = []
   if (activeInfoWindow) {
     activeInfoWindow.close()
@@ -32,14 +37,14 @@ function renderMarkers() {
   clearMarkers()
 
   const { kakao } = window
-  props.markers.forEach((restaurant) => {
+  const newMarkers = props.markers.map((restaurant) => {
     const position = new kakao.maps.LatLng(restaurant.y, restaurant.x)
-    const marker = new kakao.maps.Marker({ map, position })
+    const marker = new kakao.maps.Marker({ position })
 
     const infoContent = `
       <div style="padding:8px 12px;font-size:13px;font-family:var(--font-family);min-width:140px;">
         <strong style="display:block;margin-bottom:2px;">${restaurant.name}</strong>
-        <span style="color:#6b7280;font-size:12px;">${restaurant.category}</span>
+        <span style="color:#6b7280;font-size:12px;">${restaurant.category ?? ''}</span>
       </div>
     `
     const infoWindow = new kakao.maps.InfoWindow({ content: infoContent })
@@ -51,7 +56,27 @@ function renderMarkers() {
       emit('marker-click', restaurant)
     })
 
-    kakaoMarkers.push(marker)
+    return marker
+  })
+
+  kakaoMarkers = newMarkers
+
+  if (clusterer) {
+    clusterer.addMarkers(newMarkers)
+  } else {
+    newMarkers.forEach((m) => m.setMap(map))
+  }
+}
+
+function emitBoundsChanged() {
+  const center = map.getCenter()
+  const bounds = map.getBounds()
+  const sw = bounds.getSouthWest()
+  const ne = bounds.getNorthEast()
+  emit('bounds-changed', {
+    center: { x: center.getLng(), y: center.getLat() },
+    sw: { lat: sw.getLat(), lng: sw.getLng() },
+    ne: { lat: ne.getLat(), lng: ne.getLng() },
   })
 }
 
@@ -65,10 +90,16 @@ function initMap() {
     }
     map = new kakao.maps.Map(container, options)
 
-    kakao.maps.event.addListener(map, 'idle', () => {
-      const center = map.getCenter()
-      emit('bounds-changed', { y: center.getLat(), x: center.getLng() })
-    })
+    // MarkerClusterer (SDK에 clusterer 라이브러리 포함 시 활성화)
+    if (kakao.maps.MarkerClusterer) {
+      clusterer = new kakao.maps.MarkerClusterer({
+        map,
+        averageCenter: true,
+        minLevel: 4,
+      })
+    }
+
+    kakao.maps.event.addListener(map, 'idle', emitBoundsChanged)
 
     renderMarkers()
   })
@@ -81,7 +112,8 @@ function loadKakaoSDK() {
       return
     }
     const script = document.createElement('script')
-    script.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${import.meta.env.VITE_KAKAO_JS_KEY}&autoload=false`
+    const appkey = import.meta.env.VITE_KAKAO_JS_KEY
+    script.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${appkey}&libraries=clusterer&autoload=false`
     script.onload = () => resolve()
     script.onerror = () => reject(new Error('카카오맵 SDK 로딩 실패'))
     document.head.appendChild(script)
@@ -95,15 +127,22 @@ onMounted(async () => {
 
 watch(() => props.markers, renderMarkers, { deep: true })
 
-watch(() => props.center, (newCenter) => {
-  if (map && window.kakao) {
-    const { kakao } = window
-    map.setCenter(new kakao.maps.LatLng(newCenter.lat, newCenter.lng))
-  }
-})
+watch(
+  () => props.center,
+  (newCenter) => {
+    if (map && window.kakao) {
+      const { kakao } = window
+      map.setCenter(new kakao.maps.LatLng(newCenter.lat, newCenter.lng))
+    }
+  },
+)
 
 onBeforeUnmount(() => {
   clearMarkers()
+  if (clusterer) {
+    clusterer.clear()
+    clusterer = null
+  }
 })
 </script>
 

--- a/frontend/src/components/map/SearchBar.vue
+++ b/frontend/src/components/map/SearchBar.vue
@@ -1,0 +1,137 @@
+<template>
+  <div class="search-bar">
+    <div class="search-input-wrap">
+      <input
+        ref="inputRef"
+        v-model="query"
+        class="search-input"
+        type="search"
+        placeholder="식당 이름으로 검색"
+        autocomplete="off"
+        @input="onInput"
+        @keydown.enter.prevent="onEnter"
+        @keydown.escape="onEscape"
+        @focus="showResults = true"
+      />
+      <button
+        v-if="query"
+        class="search-clear"
+        type="button"
+        aria-label="검색어 지우기"
+        @click="onClear"
+      >
+        ✕
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue'
+
+const props = defineProps({
+  modelValue: { type: String, default: '' },
+})
+
+const emit = defineEmits(['update:modelValue', 'search', 'clear'])
+
+const inputRef = ref(null)
+const query = ref(props.modelValue)
+const showResults = ref(false)
+
+let debounceTimer = null
+
+watch(
+  () => props.modelValue,
+  (val) => {
+    query.value = val
+  },
+)
+
+function onInput() {
+  emit('update:modelValue', query.value)
+  clearTimeout(debounceTimer)
+  if (query.value.length >= 2) {
+    debounceTimer = setTimeout(() => {
+      emit('search', query.value)
+    }, 300)
+  } else if (query.value.length === 0) {
+    emit('clear')
+  }
+}
+
+function onEnter() {
+  if (query.value.length >= 2) {
+    clearTimeout(debounceTimer)
+    emit('search', query.value)
+  }
+}
+
+function onEscape() {
+  emit('clear')
+  inputRef.value?.blur()
+}
+
+function onClear() {
+  query.value = ''
+  emit('update:modelValue', '')
+  emit('clear')
+  inputRef.value?.focus()
+}
+
+function focus() {
+  inputRef.value?.focus()
+}
+
+defineExpose({ focus })
+</script>
+
+<style scoped>
+.search-bar {
+  width: 100%;
+}
+
+.search-input-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.search-input {
+  width: 100%;
+  height: 44px;
+  padding: 0 var(--space-4);
+  padding-right: 36px;
+  border: 1.5px solid var(--color-border);
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-sm);
+  background: var(--color-bg);
+  color: var(--color-text);
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.search-input:focus {
+  border-color: var(--color-primary);
+}
+
+.search-input::-webkit-search-cancel-button {
+  display: none;
+}
+
+.search-clear {
+  position: absolute;
+  right: var(--space-3);
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  line-height: 1;
+  padding: 2px;
+}
+
+.search-clear:hover {
+  color: var(--color-text);
+}
+</style>

--- a/frontend/src/components/map/SearchResults.vue
+++ b/frontend/src/components/map/SearchResults.vue
@@ -1,0 +1,136 @@
+<template>
+  <div v-if="visible" class="search-results">
+    <div v-if="loading" class="search-results__state">
+      <span class="search-results__spinner" />
+      검색 중...
+    </div>
+    <ul v-else-if="results.length > 0" class="search-results__list">
+      <li
+        v-for="item in results"
+        :key="item.kakaoApiId"
+        class="search-results__item"
+        @click="emit('select', item)"
+      >
+        <div class="search-results__name">{{ item.name }}</div>
+        <div class="search-results__meta">
+          <span class="search-results__category">{{ item.category }}</span>
+          <span v-if="item.distance" class="search-results__distance">
+            {{ formatDistance(item.distance) }}
+          </span>
+        </div>
+        <div class="search-results__address">{{ item.address }}</div>
+      </li>
+    </ul>
+    <div v-else class="search-results__state search-results__empty">
+      검색 결과가 없습니다.
+    </div>
+  </div>
+</template>
+
+<script setup>
+const props = defineProps({
+  results: { type: Array, default: () => [] },
+  loading: { type: Boolean, default: false },
+  visible: { type: Boolean, default: false },
+})
+
+const emit = defineEmits(['select'])
+
+function formatDistance(meters) {
+  if (!meters && meters !== 0) return ''
+  const m = Number(meters)
+  if (m >= 1000) return `${(m / 1000).toFixed(1)}km`
+  return `${Math.round(m)}m`
+}
+</script>
+
+<style scoped>
+.search-results {
+  position: absolute;
+  top: calc(44px + var(--space-2));
+  left: 0;
+  right: 0;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  max-height: 320px;
+  overflow-y: auto;
+  z-index: 20;
+}
+
+.search-results__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.search-results__item {
+  padding: var(--space-3) var(--space-4);
+  cursor: pointer;
+  border-bottom: 1px solid var(--color-border);
+  transition: background 0.1s;
+}
+
+.search-results__item:last-child {
+  border-bottom: none;
+}
+
+.search-results__item:hover {
+  background: var(--color-bg-secondary, #f9fafb);
+}
+
+.search-results__name {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium, 500);
+  color: var(--color-text);
+  margin-bottom: 2px;
+}
+
+.search-results__meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: 2px;
+}
+
+.search-results__category {
+  font-size: var(--font-size-xs);
+  color: var(--color-primary);
+}
+
+.search-results__distance {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+}
+
+.search-results__address {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+}
+
+.search-results__state {
+  padding: var(--space-4);
+  text-align: center;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+}
+
+.search-results__spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-primary);
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+</style>

--- a/frontend/src/components/map/__tests__/SearchBar.test.js
+++ b/frontend/src/components/map/__tests__/SearchBar.test.js
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import SearchBar from '@/components/map/SearchBar.vue'
+
+describe('SearchBar', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // ─── 렌더링 ───────────────────────────────────────────────────
+  it('input 요소가 렌더링된다', () => {
+    // Arrange & Act
+    const wrapper = mount(SearchBar)
+
+    // Assert
+    expect(wrapper.find('input[type="search"]').exists()).toBe(true)
+  })
+
+  it('초기값이 비어있으면 지우기 버튼이 보이지 않는다', () => {
+    // Arrange & Act
+    const wrapper = mount(SearchBar)
+
+    // Assert
+    expect(wrapper.find('.search-clear').exists()).toBe(false)
+  })
+
+  it('modelValue prop이 input에 반영된다', () => {
+    // Arrange & Act
+    const wrapper = mount(SearchBar, { props: { modelValue: '스타벅스' } })
+
+    // Assert
+    expect(wrapper.find('input').element.value).toBe('스타벅스')
+  })
+
+  // ─── 디바운스 검색 이벤트 ─────────────────────────────────────
+  it('2자 이상 입력 후 300ms 뒤 search 이벤트를 emit한다', async () => {
+    // Arrange
+    const wrapper = mount(SearchBar)
+    const input = wrapper.find('input')
+
+    // Act
+    await input.setValue('스타벅스')
+    await input.trigger('input')
+    expect(wrapper.emitted('search')).toBeFalsy()
+
+    vi.advanceTimersByTime(300)
+
+    // Assert
+    expect(wrapper.emitted('search')).toBeTruthy()
+    expect(wrapper.emitted('search')[0]).toEqual(['스타벅스'])
+  })
+
+  it('1자 입력 시 search 이벤트를 emit하지 않는다', async () => {
+    // Arrange
+    const wrapper = mount(SearchBar)
+
+    // Act
+    await wrapper.find('input').setValue('스')
+    await wrapper.find('input').trigger('input')
+    vi.advanceTimersByTime(300)
+
+    // Assert
+    expect(wrapper.emitted('search')).toBeFalsy()
+  })
+
+  it('연속 입력 시 마지막 입력 기준 300ms 후에만 search가 emit된다', async () => {
+    // Arrange
+    const wrapper = mount(SearchBar)
+    const input = wrapper.find('input')
+
+    // Act
+    await input.setValue('스타')
+    await input.trigger('input')
+    vi.advanceTimersByTime(100)
+
+    await input.setValue('스타벅스')
+    await input.trigger('input')
+    vi.advanceTimersByTime(300)
+
+    // Assert
+    expect(wrapper.emitted('search')).toHaveLength(1)
+    expect(wrapper.emitted('search')[0]).toEqual(['스타벅스'])
+  })
+
+  // ─── Enter 키 즉시 검색 ───────────────────────────────────────
+  it('Enter 키 입력 시 디바운스 없이 즉시 search를 emit한다', async () => {
+    // Arrange
+    const wrapper = mount(SearchBar)
+    const input = wrapper.find('input')
+
+    // Act
+    await input.setValue('한식당')
+    await input.trigger('input')
+    await input.trigger('keydown.enter')
+
+    // Assert — 타이머 없이 즉시 발생
+    expect(wrapper.emitted('search')).toBeTruthy()
+    expect(wrapper.emitted('search')[0]).toEqual(['한식당'])
+  })
+
+  // ─── 지우기 버튼 ──────────────────────────────────────────────
+  it('값이 있을 때 지우기 버튼이 표시된다', async () => {
+    // Arrange
+    const wrapper = mount(SearchBar)
+
+    // Act
+    await wrapper.find('input').setValue('스타벅스')
+    await wrapper.find('input').trigger('input')
+
+    // Assert
+    expect(wrapper.find('.search-clear').exists()).toBe(true)
+  })
+
+  it('지우기 버튼 클릭 시 clear 이벤트를 emit하고 input을 비운다', async () => {
+    // Arrange
+    const wrapper = mount(SearchBar)
+    await wrapper.find('input').setValue('스타벅스')
+    await wrapper.find('input').trigger('input')
+
+    // Act
+    await wrapper.find('.search-clear').trigger('click')
+
+    // Assert
+    expect(wrapper.emitted('clear')).toBeTruthy()
+    expect(wrapper.find('input').element.value).toBe('')
+  })
+
+  // ─── Escape 키 ────────────────────────────────────────────────
+  it('Escape 키 입력 시 clear 이벤트를 emit한다', async () => {
+    // Arrange
+    const wrapper = mount(SearchBar)
+    await wrapper.find('input').setValue('테스트')
+    await wrapper.find('input').trigger('input')
+
+    // Act
+    await wrapper.find('input').trigger('keydown.escape')
+
+    // Assert
+    expect(wrapper.emitted('clear')).toBeTruthy()
+  })
+
+  // ─── v-model ──────────────────────────────────────────────────
+  it('입력 시 update:modelValue 이벤트를 emit한다', async () => {
+    // Arrange
+    const wrapper = mount(SearchBar)
+
+    // Act
+    await wrapper.find('input').setValue('맛집')
+    await wrapper.find('input').trigger('input')
+
+    // Assert
+    expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+    expect(wrapper.emitted('update:modelValue')[0]).toEqual(['맛집'])
+  })
+})

--- a/frontend/src/components/map/__tests__/SearchResults.test.js
+++ b/frontend/src/components/map/__tests__/SearchResults.test.js
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import SearchResults from '@/components/map/SearchResults.vue'
+
+const fixtureResults = [
+  {
+    kakaoApiId: 'k1',
+    name: '스타벅스 강남점',
+    category: '카페',
+    address: '서울 강남구 테헤란로',
+    x: '127.027',
+    y: '37.498',
+    distance: '120',
+  },
+  {
+    kakaoApiId: 'k2',
+    name: '한식당',
+    category: '한식',
+    address: '서울 강남구 역삼동',
+    x: '127.028',
+    y: '37.499',
+    distance: '1500',
+  },
+]
+
+describe('SearchResults', () => {
+  // ─── visible 조건 ─────────────────────────────────────────────
+  it('visible=false 이면 아무것도 렌더링하지 않는다', () => {
+    // Arrange & Act
+    const wrapper = mount(SearchResults, {
+      props: { results: fixtureResults, visible: false },
+    })
+
+    // Assert
+    expect(wrapper.find('.search-results').exists()).toBe(false)
+  })
+
+  it('visible=true 이면 컨테이너가 렌더링된다', () => {
+    // Arrange & Act
+    const wrapper = mount(SearchResults, {
+      props: { results: fixtureResults, visible: true },
+    })
+
+    // Assert
+    expect(wrapper.find('.search-results').exists()).toBe(true)
+  })
+
+  // ─── 로딩 상태 ────────────────────────────────────────────────
+  it('loading=true 이면 로딩 텍스트를 표시한다', () => {
+    // Arrange & Act
+    const wrapper = mount(SearchResults, {
+      props: { results: [], loading: true, visible: true },
+    })
+
+    // Assert
+    expect(wrapper.text()).toContain('검색 중')
+    expect(wrapper.find('.search-results__list').exists()).toBe(false)
+  })
+
+  // ─── 결과 목록 ────────────────────────────────────────────────
+  it('results 배열만큼 항목을 렌더링한다', () => {
+    // Arrange & Act
+    const wrapper = mount(SearchResults, {
+      props: { results: fixtureResults, visible: true },
+    })
+
+    // Assert
+    const items = wrapper.findAll('.search-results__item')
+    expect(items).toHaveLength(2)
+  })
+
+  it('각 항목에 이름과 카테고리가 표시된다', () => {
+    // Arrange & Act
+    const wrapper = mount(SearchResults, {
+      props: { results: fixtureResults, visible: true },
+    })
+
+    // Assert
+    const items = wrapper.findAll('.search-results__item')
+    expect(items[0].find('.search-results__name').text()).toBe('스타벅스 강남점')
+    expect(items[0].find('.search-results__category').text()).toBe('카페')
+  })
+
+  // ─── 거리 포맷 ────────────────────────────────────────────────
+  it('distance가 1000 미만이면 m 단위로 표시한다', () => {
+    // Arrange & Act
+    const wrapper = mount(SearchResults, {
+      props: { results: [fixtureResults[0]], visible: true },
+    })
+
+    // Assert — 120m
+    expect(wrapper.find('.search-results__distance').text()).toBe('120m')
+  })
+
+  it('distance가 1000 이상이면 km 단위로 표시한다', () => {
+    // Arrange & Act
+    const wrapper = mount(SearchResults, {
+      props: { results: [fixtureResults[1]], visible: true },
+    })
+
+    // Assert — 1500 → 1.5km
+    expect(wrapper.find('.search-results__distance').text()).toBe('1.5km')
+  })
+
+  // ─── 빈 결과 ──────────────────────────────────────────────────
+  it('results가 비어있으면 empty 메시지를 표시한다', () => {
+    // Arrange & Act
+    const wrapper = mount(SearchResults, {
+      props: { results: [], visible: true },
+    })
+
+    // Assert
+    expect(wrapper.text()).toContain('검색 결과가 없습니다')
+    expect(wrapper.find('.search-results__list').exists()).toBe(false)
+  })
+
+  // ─── select 이벤트 ────────────────────────────────────────────
+  it('항목 클릭 시 select 이벤트에 해당 item을 emit한다', async () => {
+    // Arrange
+    const wrapper = mount(SearchResults, {
+      props: { results: fixtureResults, visible: true },
+    })
+
+    // Act
+    await wrapper.findAll('.search-results__item')[0].trigger('click')
+
+    // Assert
+    expect(wrapper.emitted('select')).toBeTruthy()
+    expect(wrapper.emitted('select')[0][0]).toMatchObject({ kakaoApiId: 'k1', name: '스타벅스 강남점' })
+  })
+})

--- a/frontend/src/router/__tests__/router.test.js
+++ b/frontend/src/router/__tests__/router.test.js
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import { setActivePinia, createPinia } from 'pinia'
+import { useAuthStore } from '@/stores/auth'
+
+// 라우트 정의를 직접 가져와 테스트용 라우터 생성
+// (실제 컴포넌트 lazy-import는 더미로 대체)
+const dummyComponent = { template: '<div />' }
+
+function buildRouter(isAuthenticated) {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/login', name: 'Login', component: dummyComponent, meta: { requiresAuth: false } },
+      { path: '/map', name: 'Map', component: dummyComponent, meta: { requiresAuth: true } },
+      { path: '/mypage', name: 'MyPage', component: dummyComponent, meta: { requiresAuth: true } },
+      { path: '/', redirect: '/map' },
+    ],
+  })
+
+  router.beforeEach((to) => {
+    // stores/auth를 직접 읽지 않고 주입된 값 사용
+    const authenticated = isAuthenticated()
+    if (to.meta.requiresAuth && !authenticated) {
+      return { name: 'Login', query: { redirect: to.fullPath } }
+    }
+    if (to.name === 'Login' && authenticated) {
+      return { name: 'Map' }
+    }
+  })
+
+  return router
+}
+
+describe('router beforeEach 가드', () => {
+  // ─── 비로그인 상태 ────────────────────────────────────────────
+  it('비로그인 상태에서 /map 접근 시 /login 으로 리다이렉트된다', async () => {
+    // Arrange
+    const router = buildRouter(() => false)
+    await router.push('/map')
+
+    // Assert
+    expect(router.currentRoute.value.name).toBe('Login')
+    expect(router.currentRoute.value.query.redirect).toBe('/map')
+  })
+
+  it('비로그인 상태에서 /mypage 접근 시 /login 으로 리다이렉트된다', async () => {
+    // Arrange
+    const router = buildRouter(() => false)
+    await router.push('/mypage')
+
+    // Assert
+    expect(router.currentRoute.value.name).toBe('Login')
+    expect(router.currentRoute.value.query.redirect).toBe('/mypage')
+  })
+
+  // ─── 로그인 상태 ──────────────────────────────────────────────
+  it('로그인 상태에서 /map 접근 시 정상 진입된다', async () => {
+    // Arrange
+    const router = buildRouter(() => true)
+    await router.push('/map')
+
+    // Assert
+    expect(router.currentRoute.value.name).toBe('Map')
+  })
+
+  it('로그인 상태에서 /login 접근 시 /map 으로 리다이렉트된다', async () => {
+    // Arrange
+    const router = buildRouter(() => true)
+    await router.push('/login')
+
+    // Assert
+    expect(router.currentRoute.value.name).toBe('Map')
+  })
+
+  // ─── requiresAuth: false 라우트 ───────────────────────────────
+  it('비로그인 상태에서 requiresAuth:false 라우트는 정상 접근된다', async () => {
+    // Arrange
+    const router = buildRouter(() => false)
+    await router.push('/login')
+
+    // Assert
+    expect(router.currentRoute.value.name).toBe('Login')
+  })
+})

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -18,7 +18,7 @@ const routes = [
     path: '/map',
     name: 'Map',
     component: () => import('@/views/MapView.vue'),
-    meta: { requiresAuth: false },
+    meta: { requiresAuth: true },
   },
   {
     path: '/restaurants/:id',

--- a/frontend/src/stores/__tests__/restaurant.spec.md
+++ b/frontend/src/stores/__tests__/restaurant.spec.md
@@ -1,0 +1,51 @@
+# 테스트 명세: useRestaurantStore
+
+## loadByBounds
+
+### Given: bounds 파라미터 + API 정상 응답 (배열)
+When: `loadByBounds(sw, ne)` 호출
+Then: `mapRestaurants`에 응답 배열 저장, `loading=false`, `error=null`
+
+### Given: bounds 파라미터 + API 정상 응답 (`{ restaurants, hasMore }` 형태)
+When: `loadByBounds(sw, ne)` 호출
+Then: `mapRestaurants`에 `restaurants` 저장, `hasMore=true`
+
+### Given: API 호출 진행 중
+When: `loadByBounds` 호출 직후
+Then: `loading=true`
+
+### Given: API 실패
+When: `loadByBounds(sw, ne)` 호출
+Then: `error`에 에러 객체 저장, `mapRestaurants=[]`
+
+---
+
+## searchKakao
+
+### Given: query + center
+When: `searchKakao(query, center)` 호출
+Then: API에 query와 center 전달, `searchResults`에 응답 저장, `searchLoading=false`
+
+### Given: API 실패
+When: `searchKakao(query)` 호출
+Then: `searchResults=[]`
+
+### Given: center 없음
+When: `searchKakao(query)` 호출 (center 생략)
+Then: API에 center=null 전달, 정상 동작
+
+---
+
+## clearSearch
+
+### Given: searchResults에 항목 존재
+When: `clearSearch()` 호출
+Then: `searchResults=[]`
+
+---
+
+## selectRestaurant / clearSelected
+
+### Given: 식당 객체
+When: `selectRestaurant(restaurant)` → `clearSelected()`
+Then: selected에 식당 저장 후 null로 초기화

--- a/frontend/src/stores/__tests__/restaurant.test.js
+++ b/frontend/src/stores/__tests__/restaurant.test.js
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useRestaurantStore } from '@/stores/restaurant'
+import * as restaurantApi from '@/api/restaurant'
+
+vi.mock('@/api/restaurant')
+
+describe('useRestaurantStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  // ─── loadByBounds ─────────────────────────────────────────────
+  describe('loadByBounds', () => {
+    it('bounds 내 리뷰된 식당 목록을 mapRestaurants에 저장한다', async () => {
+      // Arrange
+      const fixtures = [
+        { id: 1, name: '스타벅스 강남점', category: '카페', x: 127.027, y: 37.498 },
+        { id: 2, name: '한식당', category: '한식', x: 127.028, y: 37.499 },
+      ]
+      restaurantApi.fetchRestaurantsInBounds.mockResolvedValue(fixtures)
+      const store = useRestaurantStore()
+      const sw = { lat: 37.4, lng: 127.0 }
+      const ne = { lat: 37.6, lng: 127.1 }
+
+      // Act
+      await store.loadByBounds(sw, ne)
+
+      // Assert
+      expect(restaurantApi.fetchRestaurantsInBounds).toHaveBeenCalledWith(sw, ne)
+      expect(store.mapRestaurants).toEqual(fixtures)
+      expect(store.loading).toBe(false)
+      expect(store.error).toBeNull()
+    })
+
+    it('API 응답이 { restaurants, hasMore } 형태여도 올바르게 파싱한다', async () => {
+      // Arrange
+      const fixtures = [{ id: 3, name: '맛집', category: '일식', x: 127.01, y: 37.5 }]
+      restaurantApi.fetchRestaurantsInBounds.mockResolvedValue({
+        restaurants: fixtures,
+        hasMore: true,
+      })
+      const store = useRestaurantStore()
+
+      // Act
+      await store.loadByBounds({ lat: 37.4, lng: 127.0 }, { lat: 37.6, lng: 127.1 })
+
+      // Assert
+      expect(store.mapRestaurants).toEqual(fixtures)
+      expect(store.hasMore).toBe(true)
+    })
+
+    it('API 호출 중 loading이 true가 된다', async () => {
+      // Arrange
+      let resolveApi
+      restaurantApi.fetchRestaurantsInBounds.mockReturnValue(
+        new Promise((r) => { resolveApi = r }),
+      )
+      const store = useRestaurantStore()
+
+      // Act
+      const promise = store.loadByBounds({ lat: 37.4, lng: 127.0 }, { lat: 37.6, lng: 127.1 })
+      expect(store.loading).toBe(true)
+      resolveApi([])
+      await promise
+
+      // Assert
+      expect(store.loading).toBe(false)
+    })
+
+    it('API 실패 시 error를 저장하고 mapRestaurants를 빈 배열로 유지한다', async () => {
+      // Arrange
+      const apiError = { code: 'E001', message: '서버 오류' }
+      restaurantApi.fetchRestaurantsInBounds.mockRejectedValue(apiError)
+      const store = useRestaurantStore()
+
+      // Act
+      await store.loadByBounds({ lat: 37.4, lng: 127.0 }, { lat: 37.6, lng: 127.1 })
+
+      // Assert
+      expect(store.error).toEqual(apiError)
+      expect(store.mapRestaurants).toEqual([])
+    })
+  })
+
+  // ─── searchKakao ──────────────────────────────────────────────
+  describe('searchKakao', () => {
+    it('검색어와 center를 API에 전달하고 searchResults에 저장한다', async () => {
+      // Arrange
+      const fixtures = [
+        { kakaoApiId: 'k1', name: '스타벅스 강남점', category: '카페', x: '127.027', y: '37.498', address: '서울', distance: '120' },
+      ]
+      restaurantApi.searchRestaurants.mockResolvedValue(fixtures)
+      const store = useRestaurantStore()
+      const center = { x: 127.027, y: 37.498 }
+
+      // Act
+      await store.searchKakao('스타벅스', center)
+
+      // Assert
+      expect(restaurantApi.searchRestaurants).toHaveBeenCalledWith('스타벅스', center)
+      expect(store.searchResults).toEqual(fixtures)
+      expect(store.searchLoading).toBe(false)
+    })
+
+    it('API 실패 시 searchResults를 빈 배열로 유지한다', async () => {
+      // Arrange
+      restaurantApi.searchRestaurants.mockRejectedValue({ message: '네트워크 오류' })
+      const store = useRestaurantStore()
+
+      // Act
+      await store.searchKakao('스타벅스')
+
+      // Assert
+      expect(store.searchResults).toEqual([])
+    })
+
+    it('center 없이 호출해도 동작한다', async () => {
+      // Arrange
+      restaurantApi.searchRestaurants.mockResolvedValue([])
+      const store = useRestaurantStore()
+
+      // Act
+      await store.searchKakao('한식당')
+
+      // Assert
+      expect(restaurantApi.searchRestaurants).toHaveBeenCalledWith('한식당', null)
+    })
+  })
+
+  // ─── clearSearch ──────────────────────────────────────────────
+  describe('clearSearch', () => {
+    it('searchResults를 초기화한다', async () => {
+      // Arrange
+      restaurantApi.searchRestaurants.mockResolvedValue([{ kakaoApiId: 'k1' }])
+      const store = useRestaurantStore()
+      await store.searchKakao('test')
+      expect(store.searchResults.length).toBe(1)
+
+      // Act
+      store.clearSearch()
+
+      // Assert
+      expect(store.searchResults).toEqual([])
+    })
+  })
+
+  // ─── selectRestaurant / clearSelected ─────────────────────────
+  describe('selectRestaurant / clearSelected', () => {
+    it('식당을 선택하고 해제할 수 있다', () => {
+      // Arrange
+      const store = useRestaurantStore()
+      const restaurant = { id: 1, name: '맛집' }
+
+      // Act & Assert
+      store.selectRestaurant(restaurant)
+      expect(store.selected).toEqual(restaurant)
+
+      store.clearSelected()
+      expect(store.selected).toBeNull()
+    })
+  })
+})

--- a/frontend/src/stores/restaurant.js
+++ b/frontend/src/stores/restaurant.js
@@ -1,24 +1,58 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
-import { fetchNearbyRestaurants } from '@/api/restaurant'
+import { fetchRestaurantsInBounds, searchRestaurants } from '@/api/restaurant'
 
 export const useRestaurantStore = defineStore('restaurant', () => {
-  const nearbyList = ref([])
+  // 지도에 표시되는 리뷰된 DB 식당 목록
+  const mapRestaurants = ref([])
+  // 카카오 검색 결과 목록
+  const searchResults = ref([])
+  // 선택된 식당 (마커 클릭 등)
   const selected = ref(null)
   const loading = ref(false)
+  const searchLoading = ref(false)
   const error = ref(null)
+  const hasMore = ref(false)
 
-  async function loadNearby(x, y, radius = 1000) {
+  /**
+   * bounds 내 리뷰된 식당 조회
+   * @param {{ lat: number, lng: number }} sw
+   * @param {{ lat: number, lng: number }} ne
+   */
+  async function loadByBounds(sw, ne) {
     loading.value = true
     error.value = null
     try {
-      nearbyList.value = await fetchNearbyRestaurants(x, y, radius)
+      const result = await fetchRestaurantsInBounds(sw, ne)
+      mapRestaurants.value = Array.isArray(result) ? result : (result.restaurants ?? [])
+      hasMore.value = result.hasMore ?? false
     } catch (e) {
       error.value = e
-      nearbyList.value = []
+      mapRestaurants.value = []
     } finally {
       loading.value = false
     }
+  }
+
+  /**
+   * 카카오 키워드 검색 (백엔드 프록시)
+   * @param {string} query
+   * @param {{ x: number, y: number } | null} center
+   */
+  async function searchKakao(query, center = null) {
+    searchLoading.value = true
+    try {
+      const result = await searchRestaurants(query, center)
+      searchResults.value = Array.isArray(result) ? result : (result.results ?? [])
+    } catch (e) {
+      searchResults.value = []
+    } finally {
+      searchLoading.value = false
+    }
+  }
+
+  function clearSearch() {
+    searchResults.value = []
   }
 
   function selectRestaurant(restaurant) {
@@ -29,5 +63,18 @@ export const useRestaurantStore = defineStore('restaurant', () => {
     selected.value = null
   }
 
-  return { nearbyList, selected, loading, error, loadNearby, selectRestaurant, clearSelected }
+  return {
+    mapRestaurants,
+    searchResults,
+    selected,
+    loading,
+    searchLoading,
+    error,
+    hasMore,
+    loadByBounds,
+    searchKakao,
+    clearSearch,
+    selectRestaurant,
+    clearSelected,
+  }
 })

--- a/frontend/src/views/MapView.vue
+++ b/frontend/src/views/MapView.vue
@@ -2,30 +2,62 @@
   <div class="map-page">
     <LoadingSpinner v-if="locating" message="위치를 가져오는 중..." />
     <template v-else>
+      <!-- 검색창 영역 -->
+      <div class="map-search-overlay">
+        <SearchBar
+          ref="searchBarRef"
+          v-model="searchQuery"
+          @search="onSearch"
+          @clear="onSearchClear"
+        />
+        <SearchResults
+          :results="restaurantStore.searchResults"
+          :loading="restaurantStore.searchLoading"
+          :visible="showSearchResults"
+          @select="onSearchResultSelect"
+        />
+      </div>
+
       <KakaoMap
         :center="center"
-        :markers="restaurantStore.nearbyList"
+        :markers="restaurantStore.mapRestaurants"
         :level="4"
         @marker-click="onMarkerClick"
         @bounds-changed="onBoundsChanged"
       />
-      <button
-        v-if="movedFromOrigin"
-        class="btn btn-primary search-here-btn"
-        @click="searchHere"
-      >
-        이 위치에서 검색
-      </button>
+
+      <!-- 로딩 인디케이터 -->
       <div v-if="restaurantStore.loading" class="map-loading">
         <LoadingSpinner message="식당을 찾는 중..." />
       </div>
+
+      <!-- 에러 -->
       <ErrorMessage
         v-if="restaurantStore.error"
         class="map-error"
         :message="restaurantStore.error.message || '식당 정보를 불러올 수 없습니다.'"
         :retry="true"
-        @retry="loadRestaurants(center.lng, center.lat)"
+        @retry="retryLoad"
       />
+
+      <!-- Empty state: 리뷰된 식당 없음 -->
+      <div
+        v-if="!restaurantStore.loading && !restaurantStore.error && restaurantStore.mapRestaurants.length === 0 && boundsLoaded"
+        class="map-empty"
+      >
+        <p class="map-empty__text">
+          아직 리뷰된 식당이 없어요.<br />
+          상단 검색창에서 식당을 찾아 첫 리뷰를 남겨보세요.
+        </p>
+        <button class="btn btn-primary map-empty__btn" @click="focusSearch">
+          식당 검색하기
+        </button>
+      </div>
+
+      <!-- viewport 상한 경고 -->
+      <div v-if="restaurantStore.hasMore" class="map-has-more">
+        더 확대하면 더 많은 식당을 볼 수 있어요.
+      </div>
     </template>
   </div>
 </template>
@@ -35,6 +67,8 @@ import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useRestaurantStore } from '@/stores/restaurant'
 import KakaoMap from '@/components/map/KakaoMap.vue'
+import SearchBar from '@/components/map/SearchBar.vue'
+import SearchResults from '@/components/map/SearchResults.vue'
 import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
 import ErrorMessage from '@/components/common/ErrorMessage.vue'
 
@@ -44,14 +78,41 @@ const restaurantStore = useRestaurantStore()
 const DEFAULT_CENTER = { lat: 37.4979, lng: 127.0276 } // 강남역
 const center = ref({ ...DEFAULT_CENTER })
 const locating = ref(true)
-const movedFromOrigin = ref(false)
-let lastSearchPos = { x: 0, y: 0 }
-let currentMapCenter = { x: 0, y: 0 }
+const boundsLoaded = ref(false)
+const searchQuery = ref('')
+const showSearchResults = ref(false)
+const searchBarRef = ref(null)
 
-function loadRestaurants(x, y) {
-  lastSearchPos = { x, y }
-  movedFromOrigin.value = false
-  restaurantStore.loadNearby(x, y)
+// 현재 bounds (bounds-changed 이벤트로 갱신)
+let currentBounds = { sw: null, ne: null }
+let currentCenter = { x: DEFAULT_CENTER.lng, y: DEFAULT_CENTER.lat }
+
+// bounds 변경 시 debounce 로드
+let boundsDebounceTimer = null
+
+function scheduleBoundsLoad(sw, ne) {
+  clearTimeout(boundsDebounceTimer)
+  boundsDebounceTimer = setTimeout(() => {
+    boundsLoaded.value = false
+    restaurantStore.loadByBounds(sw, ne).finally(() => {
+      boundsLoaded.value = true
+    })
+  }, 300)
+}
+
+function onBoundsChanged({ center: c, sw, ne }) {
+  currentCenter = c
+  currentBounds = { sw, ne }
+  // 검색 결과가 열려있으면 bounds 재조회 하지 않음
+  if (!showSearchResults.value) {
+    scheduleBoundsLoad(sw, ne)
+  }
+}
+
+function retryLoad() {
+  if (currentBounds.sw && currentBounds.ne) {
+    restaurantStore.loadByBounds(currentBounds.sw, currentBounds.ne)
+  }
 }
 
 function onMarkerClick(restaurant) {
@@ -59,18 +120,40 @@ function onMarkerClick(restaurant) {
   router.push(`/restaurants/${restaurant.id}`)
 }
 
-function onBoundsChanged({ x, y }) {
-  currentMapCenter = { x, y }
-  const dx = Math.abs(x - lastSearchPos.x)
-  const dy = Math.abs(y - lastSearchPos.y)
-  if (dx > 0.005 || dy > 0.005) {
-    movedFromOrigin.value = true
-  }
+// 검색
+function onSearch(query) {
+  showSearchResults.value = true
+  restaurantStore.searchKakao(query, currentCenter)
 }
 
-function searchHere() {
-  center.value = { lat: currentMapCenter.y, lng: currentMapCenter.x }
-  loadRestaurants(currentMapCenter.x, currentMapCenter.y)
+function onSearchClear() {
+  showSearchResults.value = false
+  restaurantStore.clearSearch()
+}
+
+function onSearchResultSelect(item) {
+  // 지도를 해당 식당 좌표로 이동
+  center.value = { lat: Number(item.y), lng: Number(item.x) }
+  showSearchResults.value = false
+  searchQuery.value = item.name
+
+  // 리뷰 작성 폼으로 이동 (kakaoApiId + 스냅샷 쿼리로 전달)
+  router.push({
+    name: 'ReviewCreate',
+    query: {
+      kakaoApiId: item.kakaoApiId,
+      name: item.name,
+      category: item.category ?? '',
+      address: item.address ?? '',
+      x: item.x,
+      y: item.y,
+      placeUrl: item.placeUrl ?? '',
+    },
+  })
+}
+
+function focusSearch() {
+  searchBarRef.value?.focus()
 }
 
 onMounted(() => {
@@ -79,19 +162,17 @@ onMounted(() => {
       (pos) => {
         center.value = { lat: pos.coords.latitude, lng: pos.coords.longitude }
         locating.value = false
-        loadRestaurants(pos.coords.longitude, pos.coords.latitude)
       },
       () => {
         center.value = { ...DEFAULT_CENTER }
         locating.value = false
-        loadRestaurants(DEFAULT_CENTER.lng, DEFAULT_CENTER.lat)
       },
       { timeout: 5000 },
     )
   } else {
     locating.value = false
-    loadRestaurants(DEFAULT_CENTER.lng, DEFAULT_CENTER.lat)
   }
+  // bounds 조회는 KakaoMap의 idle 이벤트(onBoundsChanged)가 최초 발생 시 자동 트리거
 })
 </script>
 
@@ -103,18 +184,16 @@ onMounted(() => {
   position: relative;
 }
 
-.search-here-btn {
+/* 검색창 오버레이 */
+.map-search-overlay {
   position: absolute;
   top: var(--space-4);
-  left: 50%;
-  transform: translateX(-50%);
+  left: var(--space-4);
+  right: var(--space-4);
   z-index: 10;
-  box-shadow: var(--shadow-md);
-  font-size: var(--font-size-sm);
-  padding: var(--space-2) var(--space-4);
-  border-radius: var(--radius-full);
 }
 
+/* 로딩 */
 .map-loading {
   position: absolute;
   bottom: var(--space-6);
@@ -127,6 +206,7 @@ onMounted(() => {
   padding: var(--space-2) var(--space-4);
 }
 
+/* 에러 */
 .map-error {
   position: absolute;
   bottom: var(--space-6);
@@ -136,5 +216,55 @@ onMounted(() => {
   background: var(--color-bg);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-md);
+}
+
+/* Empty state */
+.map-empty {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 10;
+  background: var(--color-bg);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  padding: var(--space-5) var(--space-6);
+  text-align: center;
+  max-width: 320px;
+  width: calc(100% - var(--space-8));
+}
+
+.map-empty__text {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  margin-bottom: var(--space-4);
+  line-height: 1.6;
+}
+
+.map-empty__btn {
+  font-size: var(--font-size-sm);
+}
+
+/* 상한 경고 */
+.map-has-more {
+  position: absolute;
+  bottom: var(--space-6);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  background: var(--color-bg);
+  border-radius: var(--radius-full);
+  box-shadow: var(--shadow-md);
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+}
+
+/* 모바일: 검색창이 NavBar 위에 겹치지 않도록 */
+@media (max-width: 640px) {
+  .map-empty {
+    top: 55%;
+  }
 }
 </style>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,6 +6,11 @@ import vueDevTools from 'vite-plugin-vue-devtools'
 
 // https://vite.dev/config/
 export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: [],
+  },
   envDir: '../',
   plugins: [
     vue(),


### PR DESCRIPTION
## 개요
> 카카오맵 SDK 기반으로 viewport(bounds) 안에 "리뷰가 있는" 식당만 마커로 표시하는 검색 기반 지도로 재설계. 검색창/클러스터링/Empty state 포함.

## 관련 이슈
Closes #16

## 작업 상세 내용
- [x] `/map` 라우트 `requiresAuth: true` 가드
- [x] `KakaoMap.vue`: bounds(sw/ne) emit + `MarkerClusterer`(libraries=clusterer) 통합
- [x] `SearchBar.vue` 신규: 디바운스 300ms, 최소 2자, Enter 즉시
- [x] `SearchResults.vue` 신규: 거리 m/km 포맷, 로딩/빈 상태
- [x] `MapView.vue`: 검색창 통합, bounds 자동 재조회, Empty state, hasMore 경고, geolocation→강남역 fallback
- [x] `stores/restaurant.js`: `loadByBounds`/`searchKakao`/`mapRestaurants`/`searchResults`/`clearSearch` 재설계
- [x] `api/restaurant.js`: `fetchRestaurantsInBounds`/`searchRestaurants`로 교체
- [x] Vitest 단위 테스트: store 액션, SearchBar 디바운스, SearchResults 렌더, router 가드

## 체크리스트
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 로컬에서 테스트는 모두 통과했나요? (Vitest)
- [x] 불필요한 공백이나 주석은 제거했나요?

## 리뷰 요청 사항
> - MarkerClusterer 옵션 (`gridSize`, `minLevel`)
> - bounds debounce 300ms 충분한지
> - geolocation 폴백 동작

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added restaurant search with debounced query input and results panel displaying name, category, and distance.
  * Introduced marker clustering on the map for improved performance with many markers.
  * Map view now requires user authentication.
  * Added empty state message when no restaurants are found in the current viewing area.

* **Changes**
  * Restaurant loading now uses visible map bounds instead of proximity-based search.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->