### PR TITLE
chore(common): shell 반응형 safe-area + .env.example 주석 보강 (#18)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,18 @@
+# ============================================================
+# Enchelin 환경변수 예시
+# 실제 값을 복사하여 .env 파일을 생성하세요.
+# .env 파일은 절대 커밋하지 마세요 (gitignore 처리됨).
+# ============================================================
+
 # === Frontend ===
+
+# Kakao JavaScript 키 — 브라우저 지도 SDK 전용 (FE only)
+# 용도: 카카오맵 SDK 초기화 (new kakao.maps.Map, 마커 등)
+# 발급: https://developers.kakao.com > 내 애플리케이션 > 앱 설정 > 앱 키 > JavaScript 키
 VITE_KAKAO_JS_KEY=your-kakao-javascript-key
 
 # === Backend ===
+
 # JWT
 JWT_SECRET=your-jwt-secret-key
 JWT_EXPIRATION=3600000
@@ -11,8 +22,13 @@ GITHUB_CLIENT_ID=your-github-client-id
 GITHUB_CLIENT_SECRET=your-github-client-secret
 GITHUB_REDIRECT_URI=http://localhost:8080/api/auth/github/callback
 
-# Kakao API
-KAKAO_API_KEY=your-kakao-api-key
+# Kakao REST API 키 — 서버 사이드 장소 검색 프록시 전용 (BE only)
+# 용도: 카카오 로컬 REST API 호출 (/v2/local/search/keyword 등), 프론트엔드에 절대 노출 금지
+# 발급: https://developers.kakao.com > 내 애플리케이션 > 앱 설정 > 앱 키 > REST API 키
+KAKAO_API_KEY=your-kakao-rest-api-key
+
+# (선택) 식당 저장 시 Kakao API로 정보 재검증 여부 (기본값: false)
+# KAKAO_VERIFY_ON_CREATE=false
 
 # App
 APP_FRONTEND_URL=http://localhost:5173

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <link rel="icon" href="/favicon.ico">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <title>Enchelin</title>
   </head>
   <body>

--- a/frontend/src/assets/styles/tokens.css
+++ b/frontend/src/assets/styles/tokens.css
@@ -42,6 +42,16 @@
   --space-6: 2rem;
   --space-8: 3rem;
 
+  /* Breakpoints (reference only — use in @media, not as CSS variables) */
+  /* --bp-md: 768px  (tablet / desktop threshold) */
+  /* --bp-lg: 1024px (wide desktop) */
+
+  /* Safe-area (iOS notch / home bar) */
+  --safe-area-top: env(safe-area-inset-top, 0px);
+  --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-area-left: env(safe-area-inset-left, 0px);
+  --safe-area-right: env(safe-area-inset-right, 0px);
+
   /* Component */
   --radius-sm: 0.375rem;
   --radius-md: 0.5rem;

--- a/frontend/src/components/common/AppLayout.vue
+++ b/frontend/src/components/common/AppLayout.vue
@@ -22,6 +22,9 @@ const showNav = computed(() => !hideNavRoutes.includes(route.name))
   display: flex;
   flex-direction: column;
   min-height: 100dvh;
+  /* iOS 노치/홈바 safe-area: 좌우 패딩 */
+  padding-left: env(safe-area-inset-left, 0px);
+  padding-right: env(safe-area-inset-right, 0px);
 }
 
 .app-main {
@@ -30,8 +33,9 @@ const showNav = computed(() => !hideNavRoutes.includes(route.name))
   flex-direction: column;
 }
 
+/* 모바일: NavBar가 하단 fixed이므로 본문 하단에 NavBar 높이 + safe-area 여백 확보 */
 .app-main--with-nav {
-  padding-bottom: 56px;
+  padding-bottom: calc(56px + env(safe-area-inset-bottom, 0px));
 }
 
 @media (min-width: 768px) {
@@ -39,6 +43,7 @@ const showNav = computed(() => !hideNavRoutes.includes(route.name))
     flex-direction: column;
   }
 
+  /* 데스크톱: NavBar가 상단에 위치하므로 하단 패딩 불필요 */
   .app-main--with-nav {
     padding-bottom: 0;
   }

--- a/frontend/src/components/common/NavBar.vue
+++ b/frontend/src/components/common/NavBar.vue
@@ -33,7 +33,11 @@ const navItems = [
   background: var(--color-bg);
   border-top: 1px solid var(--color-border);
   z-index: 100;
-  padding-bottom: env(safe-area-inset-bottom);
+  /* iOS 홈바(safe-area) 반영: 하단 여백 확보 */
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+  /* iOS 사이드 safe-area 반영 */
+  padding-left: env(safe-area-inset-left, 0px);
+  padding-right: env(safe-area-inset-right, 0px);
 }
 
 .nav-item {
@@ -60,13 +64,21 @@ const navItems = [
 }
 
 @media (min-width: 768px) {
+  /* 데스크톱: 하단 fixed → 상단 sticky 전환 */
   .navbar {
-    position: static;
+    position: sticky;
+    top: 0;
+    bottom: auto;
     border-top: none;
     border-bottom: 1px solid var(--color-border);
     height: 48px;
     justify-content: center;
     gap: var(--space-8);
+    /* 상단 safe-area 반영 (노치 있는 기기 가로 모드 등) */
+    padding-top: env(safe-area-inset-top, 0px);
+    padding-bottom: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 
   .nav-item {


### PR DESCRIPTION
## 개요
> 전역 shell(AppLayout/NavBar)에 safe-area 대응 추가, 데스크톱 NavBar sticky 전환, 디자인 토큰 정비, .env.example 주석 보강.

## 관련 이슈
Closes #18

## 작업 상세 내용
- [x] `index.html`: viewport meta 정규화
- [x] `tokens.css`: 브레이크포인트 참조, safe-area CSS 변수
- [x] `AppLayout.vue`: 좌우 safe-area 패딩, 하단 calc(56px + safe-area-bottom)
- [x] `NavBar.vue`: 모바일 safe-area 사이드, 데스크톱 sticky + safe-area-top
- [x] `.env.example`: KAKAO_API_KEY(BE)/VITE_KAKAO_JS_KEY(FE) 역할 분리, 발급 URL 주석, 헤더 안내

## 체크리스트
- [x] 커밋 메시지 컨벤션
- [x] 파일 소유권 준수 (개별 뷰 및 map/review 컴포넌트 미수정)

## 리뷰 요청 사항
> - iOS Safari 노치/홈바 safe-area 적용 확인
> - NavBar 데스크톱 sticky 동작