### PR TITLE
feat(FE): AI 리뷰 요약 카드 구현 (#25)

### DIFF
--- a/frontend/src/api/restaurant.js
+++ b/frontend/src/api/restaurant.js
@@ -37,3 +37,11 @@ export function searchRestaurants(query, center = null) {
 export function fetchRestaurantDetail(restaurantId) {
   return client.get(`/restaurants/${restaurantId}`)
 }
+
+/**
+ * 식당 AI 리뷰 요약 조회
+ * @param {number} restaurantId
+ */
+export function fetchReviewSummary(restaurantId) {
+  return client.get(`/restaurants/${restaurantId}/review-summary`)
+}

--- a/frontend/src/components/review/ReviewSummaryCard.vue
+++ b/frontend/src/components/review/ReviewSummaryCard.vue
@@ -1,0 +1,179 @@
+<template>
+  <section v-if="show" class="summary-card card">
+    <h2 class="summary-title">AI 리뷰 요약</h2>
+
+    <div v-if="loading" class="skeleton-list">
+      <div v-for="n in 3" :key="n" class="skeleton-row" />
+    </div>
+
+    <template v-else-if="status === 'available'">
+      <div class="category-list">
+        <div
+          v-for="cat in visibleCategories"
+          :key="cat.key"
+          class="category-row"
+        >
+          <span class="category-label">{{ cat.label }}</span>
+          <div class="tag-list">
+            <span
+              v-for="(item, i) in cat.items"
+              :key="i"
+              class="tag-chip"
+            >
+              {{ item.tag }}
+              <span class="mention-count">{{ item.evidence_review_ids.length }}명 언급</span>
+            </span>
+          </div>
+        </div>
+      </div>
+      <p class="disclaimer">AI가 생성한 요약입니다</p>
+    </template>
+
+    <p v-else class="unavailable-msg">{{ statusMessage }}</p>
+  </section>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { fetchReviewSummary } from '@/api/restaurant'
+
+const props = defineProps({
+  restaurantId: { type: [Number, String], required: true },
+})
+
+const loading = ref(true)
+const status = ref(null)
+const summary = ref(null)
+const statusMessage = ref('')
+
+const CATEGORY_ORDER = [
+  { key: 'signature_menu', label: '대표 메뉴' },
+  { key: 'taste', label: '맛' },
+  { key: 'atmosphere', label: '분위기' },
+  { key: 'service', label: '서비스' },
+  { key: 'cost_performance', label: '가성비' },
+  { key: 'portion', label: '양' },
+  { key: 'visit_purpose', label: '방문 목적' },
+  { key: 'companion', label: '동반인' },
+  { key: 'parking', label: '주차' },
+]
+
+const show = computed(
+  () => loading.value || ['available', 'insufficient', 'unavailable'].includes(status.value),
+)
+
+const visibleCategories = computed(() => {
+  if (!summary.value) return []
+  return CATEGORY_ORDER
+    .filter((cat) => summary.value[cat.key] != null && summary.value[cat.key].length > 0)
+    .map((cat) => ({ ...cat, items: summary.value[cat.key] }))
+})
+
+onMounted(async () => {
+  try {
+    const data = await fetchReviewSummary(props.restaurantId)
+    status.value = data.status
+    summary.value = data.summary ?? null
+    statusMessage.value = data.message ?? ''
+  } catch {
+    // 요약 로드 실패 시 카드 비노출
+  } finally {
+    loading.value = false
+  }
+})
+</script>
+
+<style scoped>
+.summary-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.summary-title {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+}
+
+.skeleton-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.skeleton-row {
+  height: 1.25rem;
+  border-radius: var(--radius-sm);
+  background: linear-gradient(90deg, var(--color-bg-secondary) 25%, var(--color-border) 50%, var(--color-bg-secondary) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.2s infinite;
+}
+
+.skeleton-row:nth-child(2) {
+  width: 80%;
+}
+
+.skeleton-row:nth-child(3) {
+  width: 60%;
+}
+
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+.category-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.category-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-2);
+}
+
+.category-label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-secondary);
+  min-width: 5rem;
+  flex-shrink: 0;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.tag-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 3px 10px;
+  border-radius: var(--radius-full);
+  background-color: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+}
+
+.mention-count {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+}
+
+.disclaimer {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  text-align: right;
+}
+
+.unavailable-msg {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+</style>

--- a/frontend/src/stores/restaurant.js
+++ b/frontend/src/stores/restaurant.js
@@ -9,6 +9,8 @@ export const useRestaurantStore = defineStore('restaurant', () => {
   const searchResults = ref([])
   // 선택된 식당 (마커 클릭 등)
   const selected = ref(null)
+  // 마지막 지도 center (뒤로가기 시 위치 복원용)
+  const mapCenter = ref(null)
   const loading = ref(false)
   const searchLoading = ref(false)
   const error = ref(null)
@@ -63,10 +65,15 @@ export const useRestaurantStore = defineStore('restaurant', () => {
     selected.value = null
   }
 
+  function saveCenter(center) {
+    mapCenter.value = { ...center }
+  }
+
   return {
     mapRestaurants,
     searchResults,
     selected,
+    mapCenter,
     loading,
     searchLoading,
     error,
@@ -76,5 +83,6 @@ export const useRestaurantStore = defineStore('restaurant', () => {
     clearSearch,
     selectRestaurant,
     clearSelected,
+    saveCenter,
   }
 })

--- a/frontend/src/views/MapView.vue
+++ b/frontend/src/views/MapView.vue
@@ -103,6 +103,7 @@ function scheduleBoundsLoad(sw, ne) {
 function onBoundsChanged({ center: c, sw, ne }) {
   currentCenter = c
   currentBounds = { sw, ne }
+  restaurantStore.saveCenter({ lat: c.y, lng: c.x })
   // 검색 결과가 열려있으면 bounds 재조회 하지 않음
   if (!showSearchResults.value) {
     scheduleBoundsLoad(sw, ne)
@@ -157,6 +158,14 @@ function focusSearch() {
 }
 
 onMounted(() => {
+  // 이전에 지도를 본 적 있으면 (뒤로가기 등) 저장된 위치 복원
+  if (restaurantStore.mapCenter) {
+    center.value = { ...restaurantStore.mapCenter }
+    locating.value = false
+    return
+  }
+
+  // 최초 접속: GPS 위치로 초기화
   if ('geolocation' in navigator) {
     navigator.geolocation.getCurrentPosition(
       (pos) => {

--- a/frontend/src/views/RestaurantDetailView.vue
+++ b/frontend/src/views/RestaurantDetailView.vue
@@ -29,6 +29,8 @@
         </div>
       </section>
 
+      <ReviewSummaryCard :restaurant-id="restaurant.id" />
+
       <section class="reviews-section">
         <div class="reviews-header">
           <h2 class="reviews-title">리뷰</h2>
@@ -87,6 +89,7 @@ import ErrorMessage from '@/components/common/ErrorMessage.vue'
 import ConfirmDialog from '@/components/common/ConfirmDialog.vue'
 import ReviewList from '@/components/review/ReviewList.vue'
 import StarRating from '@/components/review/StarRating.vue'
+import ReviewSummaryCard from '@/components/review/ReviewSummaryCard.vue'
 
 const route = useRoute()
 const router = useRouter()


### PR DESCRIPTION
## 개요

식당 상세 페이지에 AI 리뷰 요약 카드를 추가합니다. BE API 응답 status에 따라 요약 내용 또는 안내 문구를 표시합니다.

## 관련 이슈

Closes #25

## 작업 상세 내용

- [x] `fetchReviewSummary` API 함수 추가 (`api/restaurant.js`)
- [x] `ReviewSummaryCard.vue` 컴포넌트 신규 생성
  - `available`: 카테고리별 태그 칩 렌더링 (대표메뉴→맛→분위기→서비스→가성비→양→방문목적→동반인→주차 순)
  - `insufficient` / `unavailable`: BE 제공 message 표시
  - 로딩 중 shimmer 애니메이션
  - API 오류 시 카드 자체 비노출 (부가 기능 silent fail)
- [x] `RestaurantDetailView.vue`에 요약 카드 통합 (restaurant-info ~ reviews-section 사이)
- [x] 지도 뒤로가기 위치 복원 버그 수정 (`MapView.vue`, `stores/restaurant.js`)
  - 식당 상세 → 뒤로가기 시 강남역으로 초기화되던 문제 해결
  - 최초 접속 시 GPS 위치로 초기화

## 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰나요?
- [ ] 로컬에서 테스트는 모두 통과했나요?
- [ ] 불필요한 공백이나 주석은 제거했나요?

## 리뷰 요청 사항

- `ReviewSummaryCard.vue`의 카테고리 키가 BE `@JsonProperty` snake_case 직렬화와 일치하는지 확인 부탁드립니다.
- 지도 위치 복원 로직 (`restaurant store mapCenter`) 방향 검토 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI-powered review summary card on restaurant detail pages, featuring categorized summaries with evidence counts and skeleton loading states while fetching data.
  * Map view now saves and restores the previously viewed map center location, enabling seamless navigation by remembering your last position when returning to the map.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->