### PR TITLE
feat(BE): 식당 AI 요약 강제 생성 API 추가

### DIFF
--- a/backend/src/main/java/com/edurican/enchelinbe/controller/RestaurantController.java
+++ b/backend/src/main/java/com/edurican/enchelinbe/controller/RestaurantController.java
@@ -10,10 +10,7 @@ import com.edurican.enchelinbe.service.ReviewSummaryService;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -68,6 +65,15 @@ public class RestaurantController {
     @GetMapping("/restaurants/{id}/review-summary")
     public ApiResponse<ReviewSummaryResponse> getReviewSummary(@PathVariable Long id) {
         return ApiResponse.success(reviewSummaryService.getSummaryForRestaurant(id));
+    }
+
+    // ---------------------------------------------------------------------------
+    // POST /restaurants/{id}/review-summary — 강제 AI 요약 생성
+    // ---------------------------------------------------------------------------
+    @PostMapping("/restaurants/{id}/review-summary")
+    public ApiResponse<Void> generateReviewSummary(@PathVariable Long id) {
+        reviewSummaryService.forceGenerateSummary(id);
+        return ApiResponse.success();
     }
 
     // ---------------------------------------------------------------------------

--- a/backend/src/main/java/com/edurican/enchelinbe/service/ReviewSummaryService.java
+++ b/backend/src/main/java/com/edurican/enchelinbe/service/ReviewSummaryService.java
@@ -45,6 +45,14 @@ public class ReviewSummaryService {
     // @Transactional 없음 — LLM 호출 중 DB 커넥션을 점유하지 않도록 의도적으로 제외.
     // 각 리포지토리 메서드는 SimpleJpaRepository의 @Transactional로 자체 트랜잭션을 가짐.
     public void generateSummaryIfStale(Long restaurantId) {
+        generateSummary(restaurantId, false);
+    }
+
+    public void forceGenerateSummary(Long restaurantId) {
+        generateSummary(restaurantId, true);
+    }
+
+    private void generateSummary(Long restaurantId, boolean force) {
         Restaurant restaurant = restaurantRepository.findById(restaurantId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.RESTAURANT_NOT_FOUND));
 
@@ -56,7 +64,7 @@ public class ReviewSummaryService {
 
         String currentHash = hashCalculator.compute(reviews);
 
-        if (!isStale(restaurantId, currentHash)) {
+        if (!force && !isStale(restaurantId, currentHash)) {
             log.debug("식당 {} 요약 최신 상태 — 스킵", restaurantId);
             return;
         }


### PR DESCRIPTION
## 개요

해시 비교를 건너뛰고 즉시 AI 요약을 재생성하는 관리용 API를 추가합니다.  
배치 실행 전 수동 트리거 또는 개발 중 smoke test에 활용합니다.

## 관련 이슈

Related #26

## 작업 상세 내용

- [x] `POST /restaurants/{id}/review-summary` 엔드포인트 추가
- [x] `ReviewSummaryService.forceGenerateSummary()` 추가
  - 내부적으로 `generateSummary(restaurantId, force=true)` 호출
  - 해시 일치 여부와 무관하게 LLM 호출 → 검증 → 저장
- [x] 기존 `generateSummaryIfStale()` 동작 변경 없음 (`force=false` 위임)

## 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰나요?
- [ ] 로컬에서 테스트는 모두 통과했나요?
- [ ] 불필요한 공백이나 주석은 제거했나요?

## 리뷰 요청 사항

- 해당 엔드포인트에 인증/권한 검사가 필요한지 검토 부탁드립니다. (현재 미인증 오픈 상태)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to manually trigger review summary generation for restaurants through a new API endpoint. Users can now request on-demand updates to restaurant review summaries, providing greater control over when summaries are created and refreshed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->