### PR TITLE
feat(BE): JWT 사용자 클레임 추가 및 리뷰 API userName·정렬·통계 구현

### DIFF
--- a/backend/src/main/java/com/edurican/enchelinbe/auth/AuthService.java
+++ b/backend/src/main/java/com/edurican/enchelinbe/auth/AuthService.java
@@ -34,6 +34,6 @@ public class AuthService {
                         .role(RoleEnum.NORMAL)
                         .build()));
 
-        return jwtProvider.createToken(user.getId());
+        return jwtProvider.createToken(user);
     }
 }

--- a/backend/src/main/java/com/edurican/enchelinbe/auth/JwtProvider.java
+++ b/backend/src/main/java/com/edurican/enchelinbe/auth/JwtProvider.java
@@ -1,5 +1,6 @@
 package com.edurican.enchelinbe.auth;
 
+import com.edurican.enchelinbe.service.User;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
@@ -27,6 +28,19 @@ public class JwtProvider {
         Date now = new Date();
         return Jwts.builder()
                 .subject(String.valueOf(userId))
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + expiration))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public String createToken(User user) {
+        Date now = new Date();
+        return Jwts.builder()
+                .subject(String.valueOf(user.getId()))
+                .claim("nickname", user.getNickname())
+                .claim("avatarUrl", user.getAvatarUrl())
+                .claim("htmlUrl", user.getHtmlUrl())
                 .issuedAt(now)
                 .expiration(new Date(now.getTime() + expiration))
                 .signWith(secretKey)

--- a/backend/src/main/java/com/edurican/enchelinbe/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/edurican/enchelinbe/common/exception/ErrorCode.java
@@ -17,6 +17,8 @@ public enum ErrorCode {
 
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "RV001", "리뷰가 존재하지 않습니다."),
 
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다."),
+
     TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, "C003", "요청이 너무 많습니다."),
 
     KAKAO_API_ERROR(HttpStatus.BAD_GATEWAY, "K001", "Kakao API 호출 중 오류가 발생했습니다."),

--- a/backend/src/main/java/com/edurican/enchelinbe/controller/ReviewController.java
+++ b/backend/src/main/java/com/edurican/enchelinbe/controller/ReviewController.java
@@ -7,6 +7,7 @@ import com.edurican.enchelinbe.common.response.ApiResponse;
 import com.edurican.enchelinbe.dto.CreateReviewRequest;
 import com.edurican.enchelinbe.dto.ReviewResponse;
 import com.edurican.enchelinbe.dto.UpdateReviewRequest;
+import com.edurican.enchelinbe.dto.UserStatsResponse;
 import com.edurican.enchelinbe.service.ReviewService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -38,10 +39,16 @@ public class ReviewController {
     @GetMapping("/users/{userId}/reviews")
     public ApiResponse<Page<ReviewResponse>> getUserReview(
             @PathVariable Long userId,
-            @ModelAttribute OffsetLimit offsetLimit
+            @ModelAttribute OffsetLimit offsetLimit,
+            @RequestParam(value = "sort", defaultValue = "latest") String sort
     ) {
-        Page<ReviewResponse> response = reviewService.getUserReview(userId, offsetLimit);
+        Page<ReviewResponse> response = reviewService.getUserReview(userId, offsetLimit, sort);
         return ApiResponse.success(response);
+    }
+
+    @GetMapping("/users/{userId}/stats")
+    public ApiResponse<UserStatsResponse> getUserStats(@PathVariable Long userId) {
+        return ApiResponse.success(reviewService.getUserStats(userId));
     }
 
     @PutMapping("/reviews/{reviewId}")

--- a/backend/src/main/java/com/edurican/enchelinbe/dto/UserStatsResponse.java
+++ b/backend/src/main/java/com/edurican/enchelinbe/dto/UserStatsResponse.java
@@ -1,0 +1,7 @@
+package com.edurican.enchelinbe.dto;
+
+public record UserStatsResponse(
+        int reviewCount,
+        double averageRating
+) {
+}

--- a/backend/src/main/java/com/edurican/enchelinbe/repository/ReviewRepository.java
+++ b/backend/src/main/java/com/edurican/enchelinbe/repository/ReviewRepository.java
@@ -22,6 +22,30 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     Slice<Review> findByUserIdAndStatusOrderByCreatedAtDesc(Long userId, EntityStatus status, Pageable pageable);
 
+    Slice<Review> findByUserIdAndStatusOrderByRatingDescCreatedAtDesc(Long userId, EntityStatus status, Pageable pageable);
+
+    @Query("""
+            SELECT r FROM Review r
+            JOIN Restaurant rest ON r.restaurantId = rest.id
+            WHERE r.userId = :userId
+              AND r.status = com.edurican.enchelinbe.enums.EntityStatus.ACTIVE
+            ORDER BY rest.name ASC, r.createdAt DESC
+            """)
+    Slice<Review> findByUserIdActiveOrderByRestaurantName(@Param("userId") Long userId, Pageable pageable);
+
+    @Query("""
+            SELECT COUNT(r) AS reviewCount, COALESCE(AVG(r.rating), 0) AS averageRating
+            FROM Review r
+            WHERE r.userId = :userId
+              AND r.status = com.edurican.enchelinbe.enums.EntityStatus.ACTIVE
+            """)
+    UserStatsProjection findUserStats(@Param("userId") Long userId);
+
+    interface UserStatsProjection {
+        Long getReviewCount();
+        Double getAverageRating();
+    }
+
     @Query("""
             SELECT COALESCE(MAX(r.visitNumber), 0)
             FROM Review r

--- a/backend/src/main/java/com/edurican/enchelinbe/service/ReviewService.java
+++ b/backend/src/main/java/com/edurican/enchelinbe/service/ReviewService.java
@@ -6,9 +6,11 @@ import com.edurican.enchelinbe.common.exception.BusinessException;
 import com.edurican.enchelinbe.common.exception.ErrorCode;
 import com.edurican.enchelinbe.dto.CreateReviewRequest;
 import com.edurican.enchelinbe.dto.ReviewResponse;
+import com.edurican.enchelinbe.dto.UserStatsResponse;
 import com.edurican.enchelinbe.enums.EntityStatus;
 import com.edurican.enchelinbe.repository.RestaurantRepository;
 import com.edurican.enchelinbe.repository.ReviewRepository;
+import com.edurican.enchelinbe.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,6 +26,7 @@ import java.util.stream.Collectors;
 public class ReviewService {
     private final RestaurantRepository restaurantRepository;
     private final ReviewRepository reviewRepository;
+    private final UserRepository userRepository;
 
     @Transactional
     public void createReview(Long userId, CreateReviewRequest request) {
@@ -62,17 +65,29 @@ public class ReviewService {
             default -> throw new BusinessException(ErrorCode.INVALID_INPUT);
         };
 
-        List<ReviewResponse> reviewResponseList = reviewSlice.getContent().stream()
-                .map(review -> toReviewResponse(review, restaurant.getName()))
+        List<Review> content = reviewSlice.getContent();
+        List<Long> userIds = content.stream().map(Review::getUserId).distinct().toList();
+        Map<Long, String> userNames = userRepository.findAllById(userIds).stream()
+                .collect(Collectors.toMap(User::getId, User::getNickname));
+
+        List<ReviewResponse> reviewResponseList = content.stream()
+                .map(review -> toReviewResponse(review, restaurant.getName(), userNames))
                 .toList();
 
         return new Page<>(reviewResponseList, reviewSlice.hasNext());
     }
 
     @Transactional(readOnly = true)
-    public Page<ReviewResponse> getUserReview(Long userId, OffsetLimit offsetLimit) {
-        Slice<Review> reviewSlice = reviewRepository.findByUserIdAndStatusOrderByCreatedAtDesc(
-                userId, EntityStatus.ACTIVE, offsetLimit.toPageable());
+    public Page<ReviewResponse> getUserReview(Long userId, OffsetLimit offsetLimit, String sort) {
+        Slice<Review> reviewSlice = switch (sort) {
+            case "latest" -> reviewRepository.findByUserIdAndStatusOrderByCreatedAtDesc(
+                    userId, EntityStatus.ACTIVE, offsetLimit.toPageable());
+            case "rating" -> reviewRepository.findByUserIdAndStatusOrderByRatingDescCreatedAtDesc(
+                    userId, EntityStatus.ACTIVE, offsetLimit.toPageable());
+            case "name" -> reviewRepository.findByUserIdActiveOrderByRestaurantName(
+                    userId, offsetLimit.toPageable());
+            default -> throw new BusinessException(ErrorCode.INVALID_INPUT);
+        };
         List<Review> content = reviewSlice.getContent();
 
         List<Long> restaurantIds = content.stream().map(Review::getRestaurantId).toList();
@@ -80,11 +95,27 @@ public class ReviewService {
         Map<Long, String> restaurantNames = restaurants.stream()
                 .collect(Collectors.toMap(Restaurant::getId, Restaurant::getName));
 
+        List<Long> userIds = content.stream().map(Review::getUserId).distinct().toList();
+        Map<Long, String> userNames = userRepository.findAllById(userIds).stream()
+                .collect(Collectors.toMap(User::getId, User::getNickname));
+
         List<ReviewResponse> reviewResponseList = content.stream()
-                .map(review -> toReviewResponse(review, restaurantNames.get(review.getRestaurantId())))
+                .map(review -> toReviewResponse(review, restaurantNames.get(review.getRestaurantId()), userNames))
                 .toList();
 
         return new Page<>(reviewResponseList, reviewSlice.hasNext());
+    }
+
+    @Transactional(readOnly = true)
+    public UserStatsResponse getUserStats(Long userId) {
+        if (!userRepository.existsById(userId)) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
+        ReviewRepository.UserStatsProjection stats = reviewRepository.findUserStats(userId);
+        return new UserStatsResponse(
+                stats.getReviewCount().intValue(),
+                stats.getAverageRating()
+        );
     }
 
     @Transactional
@@ -101,7 +132,11 @@ public class ReviewService {
         Restaurant restaurant = restaurantRepository.findById(review.getRestaurantId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.RESTAURANT_NOT_FOUND));
 
-        return toReviewResponse(review, restaurant.getName());
+        String userName = userRepository.findById(review.getUserId())
+                .map(User::getNickname)
+                .orElse(null);
+
+        return toReviewResponse(review, restaurant.getName(), Map.of(review.getUserId(), userName != null ? userName : ""));
     }
 
     @Transactional
@@ -116,11 +151,11 @@ public class ReviewService {
         review.deleted();
     }
 
-    private ReviewResponse toReviewResponse(Review review, String restaurantName) {
+    private ReviewResponse toReviewResponse(Review review, String restaurantName, Map<Long, String> userNames) {
         return new ReviewResponse(
                 review.getId(),
                 review.getUserId(),
-                null, // userName: auth 연동 후 채울 수 있으나 현재 User 조회 생략
+                userNames.getOrDefault(review.getUserId(), null),
                 review.getRestaurantId(),
                 restaurantName,
                 review.getRating(),

--- a/docs/plans/mypage-review-enhancement.md
+++ b/docs/plans/mypage-review-enhancement.md
@@ -1,0 +1,112 @@
+# 마이페이지 & 리뷰 시스템 개선 계획
+
+## Context
+GitHub OAuth로 로그인 시 nickname/avatarUrl을 받아오지만 JWT에 포함되지 않아 마이페이지에서 "사용자"로 표시됨. 리뷰 응답의 `userName`이 항상 `null`이라 댓글 작성자를 알 수 없고, 소유권 체크도 실패함. 마이페이지에 사용자 통계, 리뷰 정렬이 없으며, 리뷰 카드에 음식점 이름이 표시되지 않음.
+
+## 근본 원인
+1. **JWT에 사용자 정보 누락**: `JwtProvider.createToken(Long userId)`가 subject만 설정 → 프론트엔드 `payload.nickname` 항상 null
+2. **리뷰 응답에 userName 미설정**: `ReviewService.toReviewResponse()`가 `null` 하드코딩
+3. **마이페이지 기능 부재**: 통계/정렬 미구현, 리뷰에 음식점 이름 미표시
+
+---
+
+## Phase 1: 기반 작업 (의존성 없음)
+
+### 1-1. JWT에 사용자 클레임 추가
+**파일**: `backend/.../auth/JwtProvider.java`
+- `createToken(User user)` 오버로드 추가
+- `.claim("nickname", ...)`, `.claim("avatarUrl", ...)`, `.claim("htmlUrl", ...)` 포함
+
+**파일**: `backend/.../auth/AuthService.java`
+- `jwtProvider.createToken(user.getId())` → `jwtProvider.createToken(user)` 변경 (User 객체는 이미 로드됨)
+
+**프론트엔드 변경 없음**: `auth.js`가 이미 `payload.nickname`, `payload.avatarUrl`, `payload.htmlUrl`을 읽고 있음
+
+### 1-2. ErrorCode 추가
+**파일**: `backend/.../common/exception/ErrorCode.java`
+- `USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다.")`
+
+---
+
+## Phase 2: 리뷰 데이터 보강
+
+### 2-1. UserStatsResponse DTO
+**새 파일**: `backend/.../dto/UserStatsResponse.java`
+- `int reviewCount`, `double averageRating`
+
+### 2-2. ReviewRepository 쿼리 추가
+**파일**: `backend/.../repository/ReviewRepository.java`
+- `findByUserIdAndStatusOrderByRatingDescCreatedAtDesc(...)` — 평점순
+- `findByUserIdActiveOrderByRestaurantName(...)` — @Query JOIN으로 음식점 이름순
+- `findUserStats(Long userId)` — COUNT + AVG 단일 쿼리, `UserStatsProjection` 인터페이스
+
+### 2-3. ReviewService 수정
+**파일**: `backend/.../service/ReviewService.java`
+- `UserRepository` 주입
+- `toReviewResponse` 확장: `Map<Long, String> userNames` 파라미터 추가, `null` → `userNames.getOrDefault(...)`
+- `getRestaurantReview()`: userName 배치 조회 추가
+- `getUserReview()`: sort 파라미터 추가 (latest/name/rating), userName 배치 조회
+- `updateReview()`: 단건 유저 조회 후 응답에 포함
+- `getUserStats(Long userId)` 메서드 추가
+
+### 2-4. ReviewController 수정
+**파일**: `backend/.../controller/ReviewController.java`
+- `GET /users/{userId}/reviews`에 `sort` 파라미터 추가 (기본값 "latest")
+- `GET /users/{userId}/stats` 엔드포인트 추가
+
+---
+
+## Phase 3: 프론트엔드 (Phase 1~2 의존)
+
+### 3-1. API 함수 수정
+**파일**: `frontend/src/api/review.js`
+- `fetchUserReviews`에 `sort` 파라미터 추가
+- `fetchUserStats(userId)` 추가
+
+### 3-2. ReviewCard 수정
+**파일**: `frontend/src/components/review/ReviewCard.vue`
+- 헤더에 음식점 이름 표시 (`review.restaurantName` → RestaurantDetail 링크)
+
+### 3-3. MyPageView 수정
+**파일**: `frontend/src/views/MyPageView.vue`
+- **프로필 영역**: avatar + nickname 표시 (JWT 수정으로 자동 해결)
+- **통계 카드 추가**: 리뷰 개수 + 평균 별점 (fetchUserStats 호출)
+- **정렬 드롭다운 추가**: 최신순/이름순/평점순 (RestaurantDetailView 패턴 재사용)
+- **레이아웃 변경**: 데스크톱 2컬럼 그리드 → 단일 컬럼 (CSS `grid-template-columns: repeat(2, 1fr)` 미디어쿼리 제거)
+
+### 3-4. RestaurantDetailView 수정
+**파일**: `frontend/src/views/RestaurantDetailView.vue`
+- 소유권 체크 변경: `review.userName === auth.user.nickname` → `String(review.userId) === String(auth.user.id)`
+
+---
+
+## 수정 파일 목록
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `backend/.../auth/JwtProvider.java` | `createToken(User)` 오버로드 추가 |
+| `backend/.../auth/AuthService.java` | createToken 호출 변경 |
+| `backend/.../common/exception/ErrorCode.java` | USER_NOT_FOUND 추가 |
+| `backend/.../dto/UserStatsResponse.java` | **새 파일** — 사용자 통계 DTO |
+| `backend/.../repository/ReviewRepository.java` | 정렬 쿼리 + 통계 쿼리 추가 |
+| `backend/.../service/ReviewService.java` | userName 배치 조회, 정렬, 통계 |
+| `backend/.../controller/ReviewController.java` | 통계 엔드포인트, sort 파라미터 |
+| `frontend/src/api/review.js` | sort 파라미터, 통계 API 추가 |
+| `frontend/src/components/review/ReviewCard.vue` | 음식점 이름 표시 |
+| `frontend/src/views/MyPageView.vue` | 통계, 정렬, 단일컬럼 |
+| `frontend/src/views/RestaurantDetailView.vue` | userId 소유권 체크 |
+
+## 재사용 패턴
+- **배치 조회**: `ReviewService.getUserReview`의 restaurantNames 패턴 → userName에 동일 적용
+- **프로젝션 인터페이스**: `RestaurantReviewStats` 패턴 → `UserStatsProjection`
+- **정렬 switch**: `getRestaurantReview`의 `switch(sort)` → `getUserReview`에 동일 적용
+- **정렬 UI**: `RestaurantDetailView`의 `<select v-model="sort">` → MyPageView에 복제
+
+## 검증 방법
+1. `./gradlew build` 성공 + 기존 테스트 통과
+2. 로그인 후 JWT 디코딩하여 nickname/avatarUrl/htmlUrl 클레임 확인
+3. 마이페이지: GitHub 닉네임 + 아바타 + 통계(리뷰 수, 평균 별점) 표시 확인
+4. 마이페이지: 리뷰에 음식점 이름 표시 확인
+5. 마이페이지: 최신순/이름순/평점순 정렬 동작 확인
+6. 마이페이지: 리뷰 단일 컬럼 레이아웃 확인
+7. 식당 상세: 리뷰 작성자 이름 표시 + 본인 리뷰 수정/삭제 버튼 확인


### PR DESCRIPTION
## 개요
> GitHub OAuth 로그인 시 JWT에 nickname/avatarUrl/htmlUrl 클레임이 누락되어 마이페이지에서 "사용자"로 표시되던 문제와, 리뷰 응답의 \`userName\`이 항상 \`null\`이던 문제를 수정합니다. 아울러 마이페이지용 리뷰 정렬·통계 API를 구현합니다.

## 관련 이슈
Closes #30

## 작업 상세 내용
- [x] `JwtProvider`: `createToken(User)` 오버로드 추가 — nickname / avatarUrl / htmlUrl 클레임 포함
- [x] `AuthService`: `createToken(user.getId())` → `createToken(user)` 호출 변경
- [x] `ErrorCode`: `USER_NOT_FOUND(U001)` 추가
- [x] `UserStatsResponse`: 사용자 통계 DTO 신규 추가 (reviewCount, averageRating)
- [x] `ReviewRepository`: 유저 리뷰 평점순/음식점이름순 쿼리, `findUserStats` JPQL 쿼리 추가
- [x] `ReviewService`: `getUserReview`에 sort 파라미터 (latest/rating/name) 및 userName 배치 조회 적용, `getUserStats()` 구현
- [x] `ReviewController`: `GET /users/{userId}/stats` 엔드포인트 추가, `GET /users/{userId}/reviews`에 sort 파라미터 추가

## 체크리스트
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 로컬에서 `./gradlew compileJava` 통과 확인
- [ ] 로컬에서 테스트는 모두 통과했나요?
- [x] 불필요한 공백이나 주석은 제거했나요?

## 리뷰 요청 사항
> - `ReviewService.updateReview`에서 단건 유저 조회 방식(`findById`)이 적절한지 확인 부탁드립니다.
> - `getUserReview`의 `"name"` sort 케이스에서 사용한 JPQL JOIN 쿼리가 의도대로 동작하는지 검증 필요합니다.
> - FE 작업(Phase 3)은 별도 PR로 이어집니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added review sorting options—display reviews by latest, highest rating, or restaurant name
  * Introduced user statistics feature showing total review count and average rating
  * Enhanced authentication sessions with additional user profile information

* **Bug Fixes**
  * Improved error handling and messaging when a user profile is not found

<!-- end of auto-generated comment: release notes by coderabbit.ai -->