### PR TITLE
feat(FE): 마이페이지 통계·정렬·닉네임 표시 및 리뷰 카드 음식점 이름 추가

### DIFF
--- a/frontend/src/api/review.js
+++ b/frontend/src/api/review.js
@@ -30,10 +30,14 @@ export function fetchRestaurantReviews(restaurantId, offset = 0, limit = 10, sor
   })
 }
 
-export function fetchUserReviews(userId, offset = 0, limit = 10) {
+export function fetchUserReviews(userId, offset = 0, limit = 10, sort = 'latest') {
   return client.get(`/users/${userId}/reviews`, {
-    params: { offset, limit },
+    params: { offset, limit, sort },
   })
+}
+
+export function fetchUserStats(userId) {
+  return client.get(`/users/${userId}/stats`)
 }
 
 export function updateReview(reviewId, rating, comment) {

--- a/frontend/src/components/review/ReviewCard.vue
+++ b/frontend/src/components/review/ReviewCard.vue
@@ -7,6 +7,11 @@
       </div>
       <StarRating :rating="review.rating" size="sm" />
     </div>
+    <router-link
+      v-if="review.restaurantName"
+      :to="{ name: 'RestaurantDetail', params: { id: review.restaurantId } }"
+      class="review-restaurant"
+    >{{ review.restaurantName }}</router-link>
     <p class="review-comment">{{ review.comment }}</p>
     <div class="review-footer">
       <time class="review-date">{{ formatDate(review.createdAt) }}</time>
@@ -73,6 +78,17 @@ function formatDate(dateStr) {
   font-weight: var(--font-weight-medium);
   white-space: nowrap;
   flex-shrink: 0;
+}
+
+.review-restaurant {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.review-restaurant:hover {
+  text-decoration: underline;
 }
 
 .review-comment {

--- a/frontend/src/views/MyPageView.vue
+++ b/frontend/src/views/MyPageView.vue
@@ -23,8 +23,32 @@
       <button class="btn btn-sm btn-secondary logout-btn" @click="onLogout">로그아웃</button>
     </section>
 
+    <section v-if="stats" class="stats-card card">
+      <div class="stat-item">
+        <span class="stat-value">{{ stats.reviewCount }}</span>
+        <span class="stat-label">작성한 리뷰</span>
+      </div>
+      <div class="stat-divider" />
+      <div class="stat-item">
+        <span class="stat-value">{{ stats.averageRating.toFixed(1) }}</span>
+        <span class="stat-label">평균 별점</span>
+      </div>
+    </section>
+
     <section class="my-reviews">
-      <h2 class="section-title">내 리뷰</h2>
+      <div class="reviews-header">
+        <h2 class="section-title">내 리뷰</h2>
+        <select
+          v-model="sort"
+          class="sort-select"
+          aria-label="리뷰 정렬"
+          @change="resetAndLoad"
+        >
+          <option value="latest">최신순</option>
+          <option value="rating">별점 높은순</option>
+          <option value="name">음식점 이름순</option>
+        </select>
+      </div>
 
       <LoadingSpinner v-if="loading && reviews.length === 0" message="리뷰를 불러오는 중..." />
       <ErrorMessage
@@ -60,7 +84,7 @@ import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { useToast } from '@/composables/useToast'
-import { fetchUserReviews, deleteReview } from '@/api/review'
+import { fetchUserReviews, fetchUserStats, deleteReview } from '@/api/review'
 import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
 import ErrorMessage from '@/components/common/ErrorMessage.vue'
 import ConfirmDialog from '@/components/common/ConfirmDialog.vue'
@@ -77,13 +101,15 @@ const hasNext = ref(false)
 const offset = ref(0)
 const LIMIT = 10
 const deleteTarget = ref(null)
+const sort = ref('latest')
+const stats = ref(null)
 
 async function loadMyReviews() {
   if (!auth.user?.id) return
   loading.value = true
   error.value = ''
   try {
-    const page = await fetchUserReviews(auth.user.id, offset.value, LIMIT)
+    const page = await fetchUserReviews(auth.user.id, offset.value, LIMIT, sort.value)
     if (offset.value === 0) {
       reviews.value = page.contents
     } else {
@@ -95,6 +121,12 @@ async function loadMyReviews() {
   } finally {
     loading.value = false
   }
+}
+
+function resetAndLoad() {
+  offset.value = 0
+  reviews.value = []
+  loadMyReviews()
 }
 
 function loadMore() {
@@ -132,7 +164,10 @@ function onLogout() {
   router.replace('/login')
 }
 
-onMounted(() => {
+onMounted(async () => {
+  if (auth.user?.id) {
+    stats.value = await fetchUserStats(auth.user.id).catch(() => null)
+  }
   loadMyReviews()
 })
 </script>
@@ -193,10 +228,69 @@ onMounted(() => {
   margin-left: auto;
 }
 
+.stats-card {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-6);
+  padding: var(--space-4);
+}
+
+.stat-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.stat-value {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary);
+}
+
+.stat-label {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.stat-divider {
+  width: 1px;
+  height: 40px;
+  background: var(--color-border);
+}
+
+.reviews-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-3);
+}
+
 .section-title {
   font-size: var(--font-size-lg);
   font-weight: var(--font-weight-bold);
-  margin-bottom: var(--space-3);
+}
+
+.sort-select {
+  appearance: none;
+  -webkit-appearance: none;
+  padding: 6px 28px 6px 10px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background-color: var(--color-bg);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23666' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+  cursor: pointer;
+  min-height: 36px;
+}
+
+.sort-select:focus {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }
 
 /* 모바일: 프로필 카드 정렬 조정 */
@@ -208,15 +302,6 @@ onMounted(() => {
   .logout-btn {
     margin-left: 0;
     align-self: flex-end;
-  }
-}
-
-/* 데스크톱: 카드 레이아웃 two-column (≥1024px) */
-@media (min-width: 1024px) {
-  .my-reviews .review-list {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: var(--space-4);
   }
 }
 </style>

--- a/frontend/src/views/RestaurantDetailView.vue
+++ b/frontend/src/views/RestaurantDetailView.vue
@@ -134,7 +134,7 @@ const writeReviewRoute = computed(() => {
 })
 
 function isOwner(review) {
-  return auth.user && review.userName === auth.user.nickname
+  return auth.user && String(review.userId) === String(auth.user.id)
 }
 
 async function loadReviews() {


### PR DESCRIPTION
## 개요
> 마이페이지에서 닉네임/아바타가 표시되지 않던 문제(JWT 클레임 수정 #32 의존), 리뷰 카드에 음식점 이름이 없던 문제, 리뷰 정렬/통계 기능 부재를 해결합니다. 식당 상세 페이지의 소유권 체크도 \`userId\` 기반으로 수정합니다.

## 관련 이슈
Closes #30

## 선행 PR
> BE 작업: #32 (JWT 클레임 추가 및 리뷰 API 개선) — dev 머지 후 정상 동작

## 작업 상세 내용
- [x] `review.js`: `fetchUserReviews`에 `sort` 파라미터 추가, `fetchUserStats(userId)` 신규 추가
- [x] `ReviewCard.vue`: `review.restaurantName`이 있을 때 음식점 이름을 RestaurantDetail 링크로 표시
- [x] `MyPageView.vue`: 통계 카드(리뷰 수·평균 별점) 추가, 정렬 드롭다운(최신/별점/이름순) 추가, 데스크톱 2컬럼 그리드 제거
- [x] `RestaurantDetailView.vue`: `isOwner` — `review.userName === auth.user.nickname` → `String(review.userId) === String(auth.user.id)`

## 체크리스트
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] `npm run build` 성공 확인
- [ ] 로컬에서 테스트는 모두 통과했나요?
- [x] 불필요한 공백이나 주석은 제거했나요?

## 리뷰 요청 사항
> - `ReviewCard`의 음식점 이름 링크는 `v-if="review.restaurantName"`으로 조건부 렌더링 — 식당 상세 페이지에서는 restaurantName이 있어도 표시되므로, 식당 상세 페이지에서는 노출이 불필요하면 prop으로 제어하는 방안 검토 필요
> - 마이페이지 통계 API 실패 시 카드 자체를 숨기는 방식(catch → null)으로 처리