### PR TITLE
feat(BE): 유저 프로필 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/edurican/enchelinbe/controller/UserController.java
+++ b/backend/src/main/java/com/edurican/enchelinbe/controller/UserController.java
@@ -1,0 +1,31 @@
+package com.edurican.enchelinbe.controller;
+
+import com.edurican.enchelinbe.common.exception.BusinessException;
+import com.edurican.enchelinbe.common.exception.ErrorCode;
+import com.edurican.enchelinbe.common.response.ApiResponse;
+import com.edurican.enchelinbe.dto.UserProfileResponse;
+import com.edurican.enchelinbe.repository.UserRepository;
+import com.edurican.enchelinbe.service.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserRepository userRepository;
+
+    @GetMapping("/users/{userId}")
+    public ApiResponse<UserProfileResponse> getUserProfile(@PathVariable Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        return ApiResponse.success(new UserProfileResponse(
+                user.getId(),
+                user.getNickname(),
+                user.getAvatarUrl(),
+                user.getHtmlUrl()
+        ));
+    }
+}

--- a/backend/src/main/java/com/edurican/enchelinbe/dto/UserProfileResponse.java
+++ b/backend/src/main/java/com/edurican/enchelinbe/dto/UserProfileResponse.java
@@ -1,0 +1,9 @@
+package com.edurican.enchelinbe.dto;
+
+public record UserProfileResponse(
+        Long id,
+        String nickname,
+        String avatarUrl,
+        String htmlUrl
+) {
+}


### PR DESCRIPTION
## 개요
리뷰 작성자 닉네임 클릭 시 유저 프로필을 조회할 수 있도록 공개 API를 추가합니다.

## 관련 이슈
Closes #34

## 작업 상세 내용
- [x] `UserProfileResponse.java` DTO 추가 (id, nickname, avatarUrl, htmlUrl)
- [x] `UserController.java` 추가: `GET /users/{userId}` 공개 엔드포인트 (인증 불필요)
- [x] `USER_NOT_FOUND` 에러 처리 (기존 ErrorCode 재사용)

## 체크리스트
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 로컬에서 빌드 성공 확인했나요?
- [x] 불필요한 공백이나 주석은 제거했나요?

## 리뷰 요청 사항
> `GET /users/{userId}`는 인증 없이 공개 접근 가능합니다. 이메일, githubId 등 민감 정보는 응답에 포함하지 않고 닉네임, 아바타 URL, GitHub 링크만 반환합니다.