### PR TITLE
feat(FE): 유저 프로필 페이지 구현 및 리뷰 카드 닉네임 링크 추가

### DIFF
--- a/docs/plans/mypage-review-enhancement.md
+++ b/docs/plans/mypage-review-enhancement.md
@@ -54,6 +54,14 @@ GitHub OAuth로 로그인 시 nickname/avatarUrl을 받아오지만 JWT에 포�
 - `GET /users/{userId}/reviews`에 `sort` 파라미터 추가 (기본값 "latest")
 - `GET /users/{userId}/stats` 엔드포인트 추가
 
+### 2-5. 유저 프로필 조회 API
+**새 파일**: `backend/.../dto/UserProfileResponse.java`
+- `Long id`, `String nickname`, `String avatarUrl`, `String htmlUrl`
+
+**새 파일**: `backend/.../controller/UserController.java`
+- `GET /users/{userId}` — 공개 프로필 조회 (인증 불필요)
+- `UserRepository.findById()` → `UserProfileResponse` 반환
+
 ---
 
 ## Phase 3: 프론트엔드 (Phase 1~2 의존)
@@ -63,18 +71,35 @@ GitHub OAuth로 로그인 시 nickname/avatarUrl을 받아오지만 JWT에 포�
 - `fetchUserReviews`에 `sort` 파라미터 추가
 - `fetchUserStats(userId)` 추가
 
+**파일**: `frontend/src/api/user.js` (새 파일)
+- `fetchUserProfile(userId)` — `GET /users/{userId}` 호출
+
 ### 3-2. ReviewCard 수정
 **파일**: `frontend/src/components/review/ReviewCard.vue`
 - 헤더에 음식점 이름 표시 (`review.restaurantName` → RestaurantDetail 링크)
+- 작성자 이름 클릭 시 유저 프로필 페이지로 이동 (`/users/:userId` 링크)
 
-### 3-3. MyPageView 수정
+### 3-3. MyPageView → 공통 프로필 레이아웃 재사용
 **파일**: `frontend/src/views/MyPageView.vue`
 - **프로필 영역**: avatar + nickname 표시 (JWT 수정으로 자동 해결)
 - **통계 카드 추가**: 리뷰 개수 + 평균 별점 (fetchUserStats 호출)
 - **정렬 드롭다운 추가**: 최신순/이름순/평점순 (RestaurantDetailView 패턴 재사용)
 - **레이아웃 변경**: 데스크톱 2컬럼 그리드 → 단일 컬럼 (CSS `grid-template-columns: repeat(2, 1fr)` 미디어쿼리 제거)
+- `isMyPage` 플래그로 마이페이지 전용 요소(로그아웃 버튼, 수정/삭제) 조건부 렌더링
 
-### 3-4. RestaurantDetailView 수정
+### 3-4. UserProfileView (타인 프로필 페이지)
+**새 파일**: `frontend/src/views/UserProfileView.vue`
+- MyPageView와 동일한 레이아웃 (프로필 카드 + 통계 + 리뷰 목록 + 정렬)
+- 데이터 소스: `fetchUserProfile(userId)` + `fetchUserStats(userId)` + `fetchUserReviews(userId)`
+- **차이점**: 로그아웃 버튼 없음, 리뷰 수정/삭제 불가 (`isOwnerFn` → `() => false`)
+- 본인 프로필 접근 시(`auth.user.id === userId`) → `/mypage`로 리다이렉트
+
+### 3-5. 라우터 등록
+**파일**: `frontend/src/router/index.js`
+- `{ path: '/users/:userId', name: 'UserProfile', component: UserProfileView, meta: { requiresAuth: false } }` 추가
+- 비로그인 사용자도 조회 가능 (`requiresAuth: false`)
+
+### 3-6. RestaurantDetailView 수정
 **파일**: `frontend/src/views/RestaurantDetailView.vue`
 - 소유권 체크 변경: `review.userName === auth.user.nickname` → `String(review.userId) === String(auth.user.id)`
 
@@ -88,12 +113,17 @@ GitHub OAuth로 로그인 시 nickname/avatarUrl을 받아오지만 JWT에 포�
 | `backend/.../auth/AuthService.java` | createToken 호출 변경 |
 | `backend/.../common/exception/ErrorCode.java` | USER_NOT_FOUND 추가 |
 | `backend/.../dto/UserStatsResponse.java` | **새 파일** — 사용자 통계 DTO |
+| `backend/.../dto/UserProfileResponse.java` | **새 파일** — 유저 프로필 DTO |
+| `backend/.../controller/UserController.java` | **새 파일** — 유저 프로필 조회 API |
 | `backend/.../repository/ReviewRepository.java` | 정렬 쿼리 + 통계 쿼리 추가 |
 | `backend/.../service/ReviewService.java` | userName 배치 조회, 정렬, 통계 |
 | `backend/.../controller/ReviewController.java` | 통계 엔드포인트, sort 파라미터 |
 | `frontend/src/api/review.js` | sort 파라미터, 통계 API 추가 |
-| `frontend/src/components/review/ReviewCard.vue` | 음식점 이름 표시 |
-| `frontend/src/views/MyPageView.vue` | 통계, 정렬, 단일컬럼 |
+| `frontend/src/api/user.js` | **새 파일** — fetchUserProfile API |
+| `frontend/src/components/review/ReviewCard.vue` | 음식점 이름 + 작성자 프로필 링크 |
+| `frontend/src/views/MyPageView.vue` | 통계, 정렬, 단일컬럼, isMyPage 조건부 렌더링 |
+| `frontend/src/views/UserProfileView.vue` | **새 파일** — 타인 프로필 페이지 |
+| `frontend/src/router/index.js` | `/users/:userId` 라우트 추가 |
 | `frontend/src/views/RestaurantDetailView.vue` | userId 소유권 체크 |
 
 ## 재사용 패턴
@@ -110,3 +140,6 @@ GitHub OAuth로 로그인 시 nickname/avatarUrl을 받아오지만 JWT에 포�
 5. 마이페이지: 최신순/이름순/평점순 정렬 동작 확인
 6. 마이페이지: 리뷰 단일 컬럼 레이아웃 확인
 7. 식당 상세: 리뷰 작성자 이름 표시 + 본인 리뷰 수정/삭제 버튼 확인
+8. 리뷰 작성자 이름 클릭 → `/users/:userId` 유저 프로필 페이지 이동 확인
+9. 유저 프로필: 프로필 카드 + 통계 + 리뷰 목록 표시, 수정/삭제 버튼 없음 확인
+10. 유저 프로필: 본인 userId 접근 시 `/mypage`로 리다이렉트 확인

--- a/frontend/src/api/user.js
+++ b/frontend/src/api/user.js
@@ -1,0 +1,5 @@
+import client from './client'
+
+export function fetchUserProfile(userId) {
+  return client.get(`/users/${userId}`)
+}

--- a/frontend/src/components/review/ReviewCard.vue
+++ b/frontend/src/components/review/ReviewCard.vue
@@ -2,7 +2,12 @@
   <div class="review-card card">
     <div class="review-header">
       <div class="review-header-left">
-        <span class="review-author">{{ review.userName }}</span>
+        <router-link
+          v-if="review.userId"
+          :to="{ name: 'UserProfile', params: { userId: review.userId } }"
+          class="review-author"
+        >{{ review.userName }}</router-link>
+        <span v-else class="review-author">{{ review.userName }}</span>
         <span v-if="review.visitNumber" class="visit-badge">{{ review.visitNumber }}번째 방문</span>
       </div>
       <StarRating :rating="review.rating" size="sm" />
@@ -65,6 +70,12 @@ function formatDate(dateStr) {
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
   white-space: nowrap;
+  color: inherit;
+  text-decoration: none;
+}
+
+.review-author:hover {
+  text-decoration: underline;
 }
 
 .visit-badge {

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -47,6 +47,13 @@ const routes = [
     meta: { requiresAuth: true },
   },
   {
+    path: '/users/:userId',
+    name: 'UserProfile',
+    component: () => import('@/views/UserProfileView.vue'),
+    meta: { requiresAuth: false },
+    props: true,
+  },
+  {
     path: '/',
     redirect: '/map',
   },

--- a/frontend/src/views/UserProfileView.vue
+++ b/frontend/src/views/UserProfileView.vue
@@ -1,0 +1,266 @@
+<template>
+  <div class="profile-page container">
+    <LoadingSpinner v-if="pageLoading" message="프로필을 불러오는 중..." />
+    <ErrorMessage v-else-if="pageError" :message="pageError" :retry="true" @retry="loadProfile" />
+    <template v-else-if="profile">
+      <section class="profile-card card">
+        <img
+          v-if="profile.avatarUrl"
+          :src="profile.avatarUrl"
+          alt="프로필 이미지"
+          class="profile-avatar"
+        />
+        <div v-else class="profile-avatar profile-avatar--placeholder">👤</div>
+        <div class="profile-info">
+          <h1 class="profile-name">{{ profile.nickname }}</h1>
+          <a
+            v-if="profile.htmlUrl"
+            :href="profile.htmlUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="profile-github"
+          >
+            GitHub 프로필
+          </a>
+        </div>
+      </section>
+
+      <section v-if="stats" class="stats-card card">
+        <div class="stat-item">
+          <span class="stat-value">{{ stats.reviewCount }}</span>
+          <span class="stat-label">작성한 리뷰</span>
+        </div>
+        <div class="stat-divider" />
+        <div class="stat-item">
+          <span class="stat-value">{{ stats.averageRating.toFixed(1) }}</span>
+          <span class="stat-label">평균 별점</span>
+        </div>
+      </section>
+
+      <section class="user-reviews">
+        <div class="reviews-header">
+          <h2 class="section-title">리뷰</h2>
+          <select
+            v-model="sort"
+            class="sort-select"
+            aria-label="리뷰 정렬"
+            @change="resetAndLoad"
+          >
+            <option value="latest">최신순</option>
+            <option value="rating">별점 높은순</option>
+            <option value="name">음식점 이름순</option>
+          </select>
+        </div>
+
+        <LoadingSpinner v-if="loading && reviews.length === 0" message="리뷰를 불러오는 중..." />
+        <ErrorMessage v-else-if="error" :message="error" :retry="true" @retry="loadReviews" />
+        <template v-else>
+          <ReviewList
+            :reviews="reviews"
+            :has-next="hasNext"
+            :loading="loading"
+            :is-owner-fn="() => false"
+            @load-more="loadMore"
+          />
+        </template>
+      </section>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
+import { fetchUserProfile } from '@/api/user'
+import { fetchUserReviews, fetchUserStats } from '@/api/review'
+import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
+import ErrorMessage from '@/components/common/ErrorMessage.vue'
+import ReviewList from '@/components/review/ReviewList.vue'
+
+const route = useRoute()
+const router = useRouter()
+const auth = useAuthStore()
+
+const profile = ref(null)
+const stats = ref(null)
+const reviews = ref([])
+const pageLoading = ref(true)
+const pageError = ref('')
+const loading = ref(false)
+const error = ref('')
+const hasNext = ref(false)
+const offset = ref(0)
+const LIMIT = 10
+const sort = ref('latest')
+
+const userId = Number(route.params.userId)
+
+async function loadProfile() {
+  pageLoading.value = true
+  pageError.value = ''
+  try {
+    profile.value = await fetchUserProfile(userId)
+    stats.value = await fetchUserStats(userId).catch(() => null)
+  } catch {
+    pageError.value = '프로필을 불러올 수 없습니다.'
+  } finally {
+    pageLoading.value = false
+  }
+}
+
+async function loadReviews() {
+  loading.value = true
+  error.value = ''
+  try {
+    const page = await fetchUserReviews(userId, offset.value, LIMIT, sort.value)
+    if (offset.value === 0) {
+      reviews.value = page.contents
+    } else {
+      reviews.value.push(...page.contents)
+    }
+    hasNext.value = page.hasNext
+  } catch (e) {
+    error.value = e.message || '리뷰를 불러올 수 없습니다.'
+  } finally {
+    loading.value = false
+  }
+}
+
+function resetAndLoad() {
+  offset.value = 0
+  reviews.value = []
+  loadReviews()
+}
+
+function loadMore() {
+  offset.value += LIMIT
+  loadReviews()
+}
+
+onMounted(async () => {
+  if (auth.isAuthenticated && auth.user?.id && String(auth.user.id) === String(userId)) {
+    router.replace({ name: 'MyPage' })
+    return
+  }
+  await loadProfile()
+  loadReviews()
+})
+</script>
+
+<style scoped>
+.profile-page {
+  padding-top: var(--space-4);
+  padding-bottom: var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.profile-card {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+}
+
+.profile-avatar {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+  max-width: 100%;
+}
+
+.profile-avatar--placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-bg-secondary);
+  font-size: 1.5rem;
+}
+
+.profile-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.profile-name {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.profile-github {
+  font-size: var(--font-size-sm);
+  color: var(--color-primary);
+}
+
+.stats-card {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-6);
+  padding: var(--space-4);
+}
+
+.stat-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.stat-value {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary);
+}
+
+.stat-label {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.stat-divider {
+  width: 1px;
+  height: 40px;
+  background: var(--color-border);
+}
+
+.reviews-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-3);
+}
+
+.section-title {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+}
+
+.sort-select {
+  appearance: none;
+  -webkit-appearance: none;
+  padding: 6px 28px 6px 10px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background-color: var(--color-bg);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23666' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+  cursor: pointer;
+  min-height: 36px;
+}
+
+.sort-select:focus {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+</style>


### PR DESCRIPTION
## 개요
리뷰 작성자 닉네임을 클릭하면 해당 유저의 프로필 페이지로 이동하는 기능을 구현합니다.

## 관련 이슈
Closes #35

## 작업 상세 내용
- [x] `api/user.js` 추가: `fetchUserProfile(userId)` 함수
- [x] `ReviewCard.vue`: 작성자 닉네임을 `/users/:userId` router-link로 변경 (userId 없으면 텍스트 fallback)
- [x] `UserProfileView.vue` 추가: 프로필 카드 + 통계 + 리뷰 목록 (수정/삭제 버튼 없음)
- [x] `router/index.js`: `/users/:userId` 라우트 등록 (`requiresAuth: false`)
- [x] 본인 userId 접근 시 `/mypage`로 리다이렉트

## 체크리스트
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 로컬에서 테스트는 모두 통과했나요?
- [x] 불필요한 공백이나 주석은 제거했나요?

## 리뷰 요청 사항
> `UserProfileView`는 `MyPageView`와 동일한 레이아웃을 공유하되, 로그아웃·수정·삭제 기능을 제거했습니다. `isOwnerFn: () => false`로 처리합니다.
> BE PR(#34)의 `GET /users/{userId}` 엔드포인트가 먼저 머지되어야 정상 동작합니다.