### PR TITLE
fix(BE/FE): Critical 보안 취약점 수정 (#38)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ frontend/dist/
 .env
 .env.local
 .env.*.local
+
+# Local profile config (may contain secrets)
+backend/src/main/resources/application-local.yml

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -26,6 +26,7 @@ repositories {
 
 dependencies {
     implementation 'me.paulschwarz:spring-dotenv:4.0.0'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/backend/src/main/java/com/edurican/enchelinbe/auth/JwtProvider.java
+++ b/backend/src/main/java/com/edurican/enchelinbe/auth/JwtProvider.java
@@ -20,7 +20,14 @@ public class JwtProvider {
     public JwtProvider(
             @Value("${jwt.secret}") String secret,
             @Value("${jwt.expiration}") long expiration) {
-        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        if (secret == null || secret.isBlank()) {
+            throw new IllegalArgumentException("JWT secret must be at least 32 bytes");
+        }
+        byte[] keyBytes = secret.getBytes(StandardCharsets.UTF_8);
+        if (keyBytes.length < 32) {
+            throw new IllegalArgumentException("JWT secret must be at least 32 bytes");
+        }
+        this.secretKey = Keys.hmacShaKeyFor(keyBytes);
         this.expiration = expiration;
     }
 

--- a/backend/src/main/java/com/edurican/enchelinbe/config/WebConfig.java
+++ b/backend/src/main/java/com/edurican/enchelinbe/config/WebConfig.java
@@ -24,6 +24,6 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(rateLimitInterceptor)
-                .addPathPatterns("/restaurants/search");
+                .addPathPatterns("/restaurants/search", "/api/auth/exchange");
     }
 }

--- a/backend/src/main/java/com/edurican/enchelinbe/controller/AuthController.java
+++ b/backend/src/main/java/com/edurican/enchelinbe/controller/AuthController.java
@@ -1,7 +1,9 @@
 package com.edurican.enchelinbe.controller;
 
 import com.edurican.enchelinbe.auth.AuthService;
-import com.edurican.enchelinbe.common.response.ApiResponse;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
@@ -10,8 +12,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import java.net.URI;
 import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -29,13 +32,22 @@ public class AuthController {
     @Value("${app.frontend-url}")
     private String frontendUrl;
 
+    private final Cache<String, String> codeCache = Caffeine.newBuilder()
+            .expireAfterWrite(60, TimeUnit.SECONDS)
+            .maximumSize(1000)
+            .build();
+
     @GetMapping("/github")
-    public ResponseEntity<Void> redirectToGitHub() {
+    public ResponseEntity<Void> redirectToGitHub(HttpSession session) {
+        String state = UUID.randomUUID().toString();
+        session.setAttribute("oauth_state", state);
+
         String githubAuthUrl = UriComponentsBuilder
                 .fromUriString("https://github.com/login/oauth/authorize")
                 .queryParam("client_id", clientId)
                 .queryParam("redirect_uri", redirectUri)
                 .queryParam("scope", "read:user user:email")
+                .queryParam("state", state)
                 .build()
                 .toUriString();
 
@@ -45,25 +57,62 @@ public class AuthController {
     }
 
     @GetMapping("/github/callback")
-    public ResponseEntity<Void> githubCallback(@RequestParam String code) {
-        String token = authService.login(code);
+    public ResponseEntity<?> githubCallback(
+            @RequestParam String code,
+            @RequestParam(required = false) String state,
+            HttpSession session) {
 
-        String redirectUrl = UriComponentsBuilder
-                .fromUriString(frontendUrl)
-                .path("/auth/callback")
-                .queryParam("token", token)
-                .build()
-                .toUriString();
+        String savedState = (String) session.getAttribute("oauth_state");
+        session.removeAttribute("oauth_state");
 
-        return ResponseEntity.status(HttpStatus.FOUND)
-                .header(HttpHeaders.LOCATION, redirectUrl)
-                .build();
+        if (state == null || !state.equals(savedState)) {
+            String errorUrl = UriComponentsBuilder
+                    .fromUriString(frontendUrl)
+                    .path("/auth/callback")
+                    .queryParam("error", "invalid_state")
+                    .build()
+                    .toUriString();
+            return ResponseEntity.status(HttpStatus.FOUND)
+                    .header(HttpHeaders.LOCATION, errorUrl)
+                    .build();
+        }
+
+        try {
+            String token = authService.login(code);
+            String oneTimeCode = UUID.randomUUID().toString();
+            codeCache.put(oneTimeCode, token);
+
+            String redirectUrl = UriComponentsBuilder
+                    .fromUriString(frontendUrl)
+                    .path("/auth/callback")
+                    .queryParam("code", oneTimeCode)
+                    .build()
+                    .toUriString();
+
+            return ResponseEntity.status(HttpStatus.FOUND)
+                    .header(HttpHeaders.LOCATION, redirectUrl)
+                    .build();
+        } catch (Exception e) {
+            String errorUrl = UriComponentsBuilder
+                    .fromUriString(frontendUrl)
+                    .path("/auth/callback")
+                    .queryParam("error", "auth_failed")
+                    .build()
+                    .toUriString();
+            return ResponseEntity.status(HttpStatus.FOUND)
+                    .header(HttpHeaders.LOCATION, errorUrl)
+                    .build();
+        }
     }
 
-    @PostMapping("/github/token")
-    public ApiResponse<Map<String, String>> githubToken(@RequestBody Map<String, String> request) {
-        String code = request.get("code");
-        String token = authService.login(code);
-        return ApiResponse.success(Map.of("token", token));
+    @PostMapping("/exchange")
+    public ResponseEntity<?> exchangeCode(@RequestBody Map<String, String> body) {
+        String code = body.get("code");
+        String token = codeCache.getIfPresent(code);
+        if (token == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid or expired code");
+        }
+        codeCache.invalidate(code);
+        return ResponseEntity.ok(Map.of("token", token));
     }
 }

--- a/backend/src/main/java/com/edurican/enchelinbe/controller/RestaurantController.java
+++ b/backend/src/main/java/com/edurican/enchelinbe/controller/RestaurantController.java
@@ -68,15 +68,6 @@ public class RestaurantController {
     }
 
     // ---------------------------------------------------------------------------
-    // POST /restaurants/{id}/review-summary — 강제 AI 요약 생성
-    // ---------------------------------------------------------------------------
-    @PostMapping("/restaurants/{id}/review-summary")
-    public ApiResponse<Void> generateReviewSummary(@PathVariable Long id) {
-        reviewSummaryService.forceGenerateSummary(id);
-        return ApiResponse.success();
-    }
-
-    // ---------------------------------------------------------------------------
     // GET /restaurant/nearby (기존 엔드포인트 유지 - 구 RestaurentController 대체)
     // ---------------------------------------------------------------------------
     @GetMapping("/restaurant/nearby")

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
    active: ${SPRING_PROFILES_ACTIVE:local}
 
 jwt:
-  secret: ${JWT_SECRET:default-dev-secret-key-that-should-be-changed-in-production-env}
+  secret: ${JWT_SECRET}
   expiration: ${JWT_EXPIRATION:3600000}
 
 github:

--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -5,5 +5,5 @@ export function getGithubLoginUrl() {
 }
 
 export function exchangeToken(code) {
-  return client.post('/api/auth/github/token', { code })
+  return client.post('/api/auth/exchange', { code })
 }

--- a/frontend/src/views/AuthCallbackView.vue
+++ b/frontend/src/views/AuthCallbackView.vue
@@ -10,6 +10,7 @@ import { ref, onMounted } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { useToast } from '@/composables/useToast'
+import { exchangeToken } from '@/api/auth'
 import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
 import ErrorMessage from '@/components/common/ErrorMessage.vue'
 
@@ -19,11 +20,27 @@ const auth = useAuthStore()
 const toast = useToast()
 const errorMsg = ref('')
 
-onMounted(() => {
-  const token = route.query.token
-  if (token) {
-    auth.setToken(token)
-    router.replace('/map')
+onMounted(async () => {
+  if (route.query.error) {
+    errorMsg.value = '인증에 실패했습니다.'
+    toast.error('로그인에 실패했습니다. 다시 시도해주세요.')
+    setTimeout(() => router.replace('/login'), 2000)
+    return
+  }
+
+  const code = route.query.code
+  if (code) {
+    try {
+      const res = await exchangeToken(code)
+      const token = res.data?.token ?? res.data?.data?.token
+      if (!token) throw new Error('token missing')
+      auth.setToken(token)
+      router.replace('/map')
+    } catch {
+      errorMsg.value = '인증에 실패했습니다.'
+      toast.error('로그인에 실패했습니다. 다시 시도해주세요.')
+      setTimeout(() => router.replace('/login'), 2000)
+    }
   } else {
     errorMsg.value = '인증에 실패했습니다.'
     toast.error('로그인에 실패했습니다. 다시 시도해주세요.')


### PR DESCRIPTION
## 개요
백엔드 보안 리뷰에서 발견된 Critical 취약점 4개를 수정합니다. OAuth CSRF, JWT 토큰 URL 노출, 인가 없는 AI 요약 강제 실행 엔드포인트, JWT secret 하드코딩 이슈를 모두 제거합니다.

## 관련 이슈
Closes #38

## 작업 상세 내용
- [x] JWT secret 기본값 제거 (`application.yml`) — 미설정 시 기동 실패
- [x] `JwtProvider` 생성자에서 32바이트 미만 secret 시 `IllegalArgumentException`
- [x] OAuth state 파라미터 생성·검증 추가 — CSRF 방어 (`AuthController`)
- [x] JWT URL 노출 제거: one-time code (Caffeine, TTL 60s) → `POST /api/auth/exchange` 교환 흐름
- [x] 구 `POST /github/token` 엔드포인트 제거 (state 검증 우회 경로 차단)
- [x] `POST /restaurants/{id}/review-summary` 엔드포인트 제거 (내부 스케줄 생성만 유지)
- [x] `/api/auth/exchange` 레이트리밋 추가 (`WebConfig`)
- [x] OAuth 에러 시 JSON 응답 대신 `?error=` 쿼리로 프론트엔드 리다이렉트
- [x] FE: `auth.js` exchange 엔드포인트 반영, `AuthCallbackView` code 교환 흐름 반영
- [x] `application-local.yml` gitignore 추가

## 체크리스트
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 로컬에서 빌드 확인 (`./gradlew build -x test` + `npm run build`) 완료
- [x] 불필요한 공백이나 주석은 제거했나요?

## 리뷰 요청 사항
- `AuthController`의 one-time code 캐시가 현재 컨트롤러 필드에 선언됨 — 단일 인스턴스 환경에서는 동작하나, 멀티 인스턴스 시 캐시 미스 발생 가능. 현재 단계에서는 허용하고 PR-2에서 `@Bean` 분리 예정.
- OAuth state가 `HttpSession`에 저장됨 — 멀티 인스턴스 배포 시 sticky session 필요. 동일하게 PR-2에서 개선 예정.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced OAuth security with state validation to prevent unauthorized access attempts.
  * Implemented secure token exchange using one-time codes instead of direct URL-based token exposure.

* **Bug Fixes**
  * Fixed authentication callback flow to properly handle OAuth state validation and error scenarios.

* **Chores**
  * Added local configuration file to `.gitignore` to prevent secret exposure.
  * Removed unused token-generation endpoint; token exchange now routes through the new exchange endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->